### PR TITLE
Fixes related to issue #17

### DIFF
--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -42,7 +42,8 @@ interface Ignore {
 }
 
 const ZIP_TARGET = '__deployer__.zip'
-const BUILDER_ACTION_STEM = '/nimbella/builder/build_'
+const BUILDER_NAMESPACE = process.env['TEST_BUILDER_NAMESPACE'] || 'nimbella'
+const BUILDER_ACTION_STEM = `/${BUILDER_NAMESPACE}/builder/build_`
 const CANNED_REMOTE_BUILD = `
 #!/bin/bash
 /bin/defaultBuild

--- a/src/util.ts
+++ b/src/util.ts
@@ -1205,7 +1205,7 @@ export function delay(millis: number): Promise<void> {
 // Await the completion of an action invoke (similar to kui's await)
 export async function waitForActivation(id: string, wsk: Client, waiting: () => void): Promise<Activation<Dict>> {
   debug(`waiting for activation with id ${id}`)
-  for (let i = 1; i < 151; i++) {
+  for (let i = 1 ;; i++) {
     try {
       const activation = await wsk.activations.get(id)
       if (activation.end || activation.response.status) {
@@ -1222,7 +1222,6 @@ export async function waitForActivation(id: string, wsk: Client, waiting: () => 
     }
     await delay(1000)
   }
-  throw new Error(`Timed out waiting for activation with id ${id}`)
 }
 
 // Subroutine to invoke OW with a GET and return the response.  Bypasses the OW client.  Used


### PR DESCRIPTION
This PR contains fixes to two small problems encountered while debugging remote build problems.   As outlined in issue #17.

1.   To allow longer running builds (limited only by the action timeout) I simply removed the timeout on the slow-poll for action completion.   The poll can still be terminated if there is an error code other than 404.   Otherwise, it will almost always hang in there and wait for the action to complete or timeout.   In some instances, it might have to be interrupted manually but I see that as the lesser evil.

2.  To support debugging remote build actions without access to Nimbella internal repos or builds, I allow the `/nimbella/builder` package to be replaced by `/<anynamespace>/builder` where (typically) the namespace is the one owned by the developer.   The mechanism is to set an environment variable `TEST_BUILDER_NAMESPACE` to the desired value.