### PR TITLE
Improvements to error display esp. remote build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lib
 node_modules
 nimbella-deployer-*.tgz
+*.bak

--- a/tests/unit/util.test.ts
+++ b/tests/unit/util.test.ts
@@ -36,7 +36,13 @@ describe('test validation of loading project configuration', () => {
       }
     }
     const result = await loadProjectConfig('project.yml', '', '', (reader as unknown) as ProjectReader, null, {} as RuntimesConfig)
-    expect(result.error.message).toBe(`Invalid project configuration file (project.yml): Cannot read property 'slice' of undefined`)
+    let expectedText
+    if (process.version.startsWith('v16')) {
+      expectedText = `Cannot read properties of undefined (reading 'slice')`
+    } else {
+      expectedText = `Cannot read property 'slice' of undefined`
+    }
+    expect(result.error.message).toBe(`Invalid project configuration file (project.yml): ${expectedText}`)
   })
   test('should parse minimal YAML file', async () => {
     const reader = {


### PR DESCRIPTION
As I accumulate improvements to error feedback from remote build actions, it becomes clearer that the display of results when there is a remote error needs some tweaking.   This is a small aesthetic change.   The effect is that instead of (e.g.)

```
 ›   Error: While deploying running remote build for test: Remote error ' ›   Error: 'swift:5.4' is not a valid runtime value
```

the display is changed to
```
 ›   Error: While deploying 'test' (running remote build):  'swift:5.4' is not a valid runtime value
```

Other error displays are incidentally improved too, by standardizing the conventions for the `context` argument used for error displays.  This avoids weird wordings like "While deploying running ...".