### PR TITLE
Support getting metadata concerning a project

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,8 @@ export {
   switchGithubAccount, getPostmanKeys, deletePostmanKey, switchPostmanKey, addPostmanKey, getPostmanCurrentKey, addCommanderData, recordNamespaceOwnership, nimbellaDir, setInBrowser
 } from './credentials'
 export { cleanBucket, restore404Page, makeStorageClient } from './deploy-to-bucket'
-export { wskRequest, inBrowser, delay, writeSliceResult, getBestProjectName, isTextType, renamePackage, setInBrowserFlag, getExclusionList, isExcluded, SYSTEM_EXCLUDE_PATTERNS } from './util'
+export { wskRequest, inBrowser, delay, writeSliceResult, getBestProjectName, isTextType, renamePackage, setInBrowserFlag, getExclusionList, isExcluded, 
+  SYSTEM_EXCLUDE_PATTERNS, getRuntimeForAction } from './util'
 export * from './runtimes'
 export { GithubDef, isGithubRef, parseGithubRef, fetchProject } from './github'
 export { deleteSlice } from './slice-reader'

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,3 +35,4 @@ export { wskRequest, inBrowser, delay, writeSliceResult, getBestProjectName, isT
 export * from './runtimes'
 export { GithubDef, isGithubRef, parseGithubRef, fetchProject } from './github'
 export { deleteSlice } from './slice-reader'
+export { makeIncluder } from './includer'


### PR DESCRIPTION
It seems useful for the Nimbella CLI to have a command to retrieve all the metadata of a project (what is in the project after all information is merged from the filesystem and config file and the defaults are applied).

This PR includes minor changes to the deployer and exposure of some additional utilities to support that effort.

nimbella/nimbella-cli#187.