### PR TITLE
Change remote build to use a specialized "build" bucket when present

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1334,33 +1334,6 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.3.tgz",
       "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
     },
-    "@google-cloud/storage": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.13.1.tgz",
-      "integrity": "sha512-iOyHn5pkIQY7AYdMmpo2FScHz12pE58ZECXmwUJXHP8pGpin8yQDjSxtKtOiFaSObI3mS5/DvsyYwDvg15NMlA==",
-      "requires": {
-        "@google-cloud/common": "^3.7.0",
-        "@google-cloud/paginator": "^3.0.0",
-        "@google-cloud/promisify": "^2.0.0",
-        "arrify": "^2.0.0",
-        "async-retry": "^1.3.1",
-        "compressible": "^2.0.12",
-        "date-and-time": "^2.0.0",
-        "duplexify": "^4.0.0",
-        "extend": "^3.0.2",
-        "gcs-resumable-upload": "^3.3.0",
-        "get-stream": "^6.0.0",
-        "hash-stream-validation": "^0.2.2",
-        "mime": "^2.2.0",
-        "mime-types": "^2.0.8",
-        "onetime": "^5.1.0",
-        "p-limit": "^3.0.1",
-        "pumpify": "^2.0.0",
-        "snakeize": "^0.1.0",
-        "stream-events": "^1.0.1",
-        "xdg-basedir": "^4.0.0"
-      }
-    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -2030,35 +2003,20 @@
       }
     },
     "@nimbella/sdk": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@nimbella/sdk/-/sdk-1.3.1.tgz",
-      "integrity": "sha512-kCusIFvNvPpnH97bFHWccAv0asxbrqYvJmB3AMHk/UKz2vYW0tZ1aqSvpruXo2Ynm0d/lYip7HR9lEPa0QyuBA==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@nimbella/sdk/-/sdk-1.3.5.tgz",
+      "integrity": "sha512-NXlNz+UUxzEjjjsTdNho87PEhT103g2xFZghTneLcj4kZMmk/ulmEkguKoYW4W+pnVh02fcc75UgFUwLJY+iaA==",
       "requires": {
-        "@nimbella/storage": "^0.0.2",
+        "@nimbella/storage": "^0.0.7",
         "bluebird": "^3.7.2",
         "mysql2": "^2.1.0",
         "redis": "^3.0.2"
-      },
-      "dependencies": {
-        "@nimbella/storage": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/@nimbella/storage/-/storage-0.0.2.tgz",
-          "integrity": "sha512-JykpVkOVC9TsnnVdpajKN8MgvZFbXWP3p7YNoZbSIOUf2qM2qm1kA1QBCIqs23ccZAni6jQYGKIZDqLWr+XNxg==",
-          "requires": {
-            "@aws-sdk/client-s3": "^3.13.0",
-            "@aws-sdk/s3-request-presigner": "^3.13.0",
-            "@google-cloud/storage": "^5.8.3",
-            "@types/debug": "^4.1.5",
-            "debug": "^4.3.1",
-            "memory-streams": "^0.1.3"
-          }
-        }
       }
     },
     "@nimbella/storage": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@nimbella/storage/-/storage-0.0.5.tgz",
-      "integrity": "sha512-G3L/zzupEUdVzAffFl+wjBGYiCD51hioIcQUDfcJv3/Y/2u18691YrSZd3sHAKPKDhnmL4xDyVh11TNUcy34aA==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@nimbella/storage/-/storage-0.0.7.tgz",
+      "integrity": "sha512-FEsYes0L79oiKCAikrPI2x8CpqqqbfvEIBka/X7//b7tA8p2+k3hkSWkIW30zKK0HVb7bDYVh9Bie6ivFZ1ekg==",
       "requires": {
         "@aws-sdk/client-s3": "^3.13.0",
         "@aws-sdk/s3-request-presigner": "^3.13.0",
@@ -3159,11 +3117,6 @@
         "whatwg-url": "^8.0.0"
       }
     },
-    "date-and-time": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-2.0.0.tgz",
-      "integrity": "sha512-HJSzj25iPm8E01nt+rSmCIlwjsmjvKfUivG/kXBglpymcHF1FolWAqWwTEV4FvN1Lx5UjPf0J1W4H8yQsVBfFg=="
-    },
     "debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -3203,9 +3156,9 @@
       "dev": true
     },
     "denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
     },
     "deprecation": {
       "version": "2.3.1",
@@ -6087,13 +6040,13 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mysql2": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.0.tgz",
-      "integrity": "sha512-0t5Ivps5Tdy5YHk5NdKwQhe/4Qyn2pload+S+UooDBvsqngtzujG1BaTWBihQLfeKO3t3122/GtusBtmHEHqww==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.3.tgz",
+      "integrity": "sha512-wxJUev6LgMSgACDkb/InIFxDprRa6T95+VEoR+xPvtngtccNH2dGjEB/fVZ8yg1gWv1510c9CvXuJHi5zUm0ZA==",
       "requires": {
-        "denque": "^1.4.1",
+        "denque": "^2.0.1",
         "generate-function": "^2.3.1",
-        "iconv-lite": "^0.6.2",
+        "iconv-lite": "^0.6.3",
         "long": "^4.0.0",
         "lru-cache": "^6.0.0",
         "named-placeholders": "^1.1.2",
@@ -6495,6 +6448,13 @@
         "redis-commands": "^1.7.0",
         "redis-errors": "^1.2.0",
         "redis-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "denque": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+          "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
+        }
       }
     },
     "redis-commands": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "author": "Nimbella Corporation",
   "license": "Apache-2.0",
   "dependencies": {
-    "@nimbella/sdk": "^1.3.1",
-    "@nimbella/storage": "^0.0.5",
+    "@nimbella/sdk": "^1.3.5",
+    "@nimbella/storage": "^0.0.7",
     "@octokit/rest": "^18.7.0",
     "adm-zip": "^0.4.16",
     "anymatch": "^3.1.1",

--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -694,7 +694,7 @@ async function invokeRemoteBuilder(zipped: Buffer, credentials: Credentials, owC
   const remoteName = getRemoteBuildName()
   const urlResponse = await owClient.actions.invoke({
     name: '/nimbella/websupport/getSignedUrl',
-    params: { fileName: remoteName, dataBucket: true },
+    params: { fileName: remoteName, bucketType: 'build' },
     blocking: true,
     result: true
   })

--- a/src/slice-reader.ts
+++ b/src/slice-reader.ts
@@ -30,7 +30,7 @@ const S3_PROVIDER = '@nimbella/storage-s3'
 // This is the anchor for the nimbella sdk.  It is included dynamically instead of statically due to
 // webpack considerations in the workbench.  We do not want the dependency followed during module
 // initialization but only on demand.
-let nim: { storageClient: () => StorageClient | PromiseLike<StorageClient> }
+let nim: { storageClient: (type?: string|boolean) => StorageClient | PromiseLike<StorageClient> }
 
 // Get the cache area
 function cacheArea() {
@@ -60,7 +60,7 @@ export async function fetchSlice(sliceName: string): Promise<string> {
   }
   debug('Making cache directory: %s', cache)
   fs.mkdirSync(cache, { recursive: true })
-  const bucket: StorageClient = await getNim().storageClient()
+  const bucket: StorageClient = await getNim().storageClient('build')
   debug('have bucket client')
   const remoteFile = bucket.file(sliceName)
   debug('have remote file for %s', sliceName)
@@ -99,7 +99,7 @@ export async function fetchSlice(sliceName: string): Promise<string> {
 export async function deleteSlice(project: DeployStructure): Promise<void> {
   const sliceName = path.relative(cacheArea(), project.filePath)
   const slicePath = path.join(BUCKET_BUILDER_PREFIX, sliceName)
-  const bucket: StorageClient = await getNim().storageClient()
+  const bucket: StorageClient = await getNim().storageClient('build')
   const remoteFile = bucket.file(slicePath)
   await remoteFile.delete()
 }


### PR DESCRIPTION
This change (which also requires new versions of `@nimbella/storage` and `@nimbella/sdk`, as reflected in the `package*.json` files) makes it possible to request a `StorageClient` handle for buckets of other types besides "web" and "data."   The immediate use is for remote build, which will use a "build" bucket type.

To preserve legacy behavior, when this is used on existing GCP and AWS clusters, the requested bucket type is advisory, and, if the storage credentials don't indicate the presence of the requested bucket type, the request doesn't fail but reverts to the standard data bucket.