### PR TITLE
Fix runtimes init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -133,9 +133,11 @@ export async function load(apihost: string): Promise<RuntimesConfig> {
 // API host parameter is used as the cache key.
 // The cached values will be returned after the first call.
 export async function init(): Promise<RuntimesConfig> {
-  const creds = await getCredentials(authPersister)
-  const apihost = creds.ow.apihost
-  debug_log(`init: creds (${creds})`)
+  // Determine the API host either by reading the credential store or looking in the environment.
+  // The latter is needed when running in a container performing remote build, since there may not be
+  // any credential store.
+  const store = authPersister.loadCredentialStoreIfPresent()
+  const apihost = store?.currentHost || process.env.__OW_API_HOST || process.env.savedOW_API_HOST
   if (!apihost) throw new Error('Missing APIHOST parameter from current credentials')
   if (!RuntimesCache[apihost]) {
     RuntimesCache[apihost] = await load(apihost)

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -132,7 +132,7 @@ export async function load(apihost: string): Promise<RuntimesConfig> {
 // The parsed runtime configuration will be stored in a local cache.
 // API host parameter is used as the cache key.
 // The cached values will be returned after the first call.
-export async function init(): Promise<RuntimesConfig> {
+export async function initRuntimes(): Promise<RuntimesConfig> {
   // Determine the API host either by reading the credential store or looking in the environment.
   // The latter is needed when running in a container performing remote build, since there may not be
   // any credential store.


### PR DESCRIPTION
This fixes a problem in the recently added `runtimes.ts`.  The problem breaks remote build.  I suspect this hasn't been seen in production because the copy of `nim` in production runtimes is old enough not to have the problem.

The `init` function (renamed to `initRuntimes` in this PR) assumes there is a valid credential store with a current namespace.  This will not be true in a runtime container when doing a remote build.   The only needed value is the API host.  It happens that in a runtime container that can be obtained from the environment.  So, a dual strategy for getting the value fixes the problem in practice. 

This also declares a new patch version.   Technically, the change is incompatible because of renaming `init` to `initRuntimes`, but this method was exported just for use in the CLI and never documented.   I will declare a matching version in the CLI as soon as this is merged and published.

