### PR TITLE
Better error message after remote build error

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -118,10 +118,13 @@ async function processRemoteResponse(activationId: string, owClient: openwhisk.C
   }
   if (!activation.response || !activation.response.success) {
     let err = 'Remote build failed to provide a result'
-    if (activation?.response?.result?.error) {
-      err = activation.response.result.error
-      const parts = err.split("Error:")
-      err = parts[parts.length - 1]
+    const resultError = activation?.response?.result?.error
+    if (resultError) {
+      const errMsg = typeof resultError === 'string' ? resultError : resultError.message
+      if (typeof errMsg === 'string') {
+        const parts = errMsg.split("Error:")
+        err = parts[parts.length - 1]
+      }
     }
     return wrapError(new Error(err), context + ' (running remote build)')
   }


### PR DESCRIPTION
When the result of a a remote build action invocation contains an error, the code was assuming the error was a string.  Sometimes it is not, and, in that case, the original error would be masked by a type error.   It may not be feasible to recognize all possible error structures that may be returned, but, at least this change recognizes the situation, attempts to extract a usable message, and doesn't throw a secondary type error.