### PR TITLE
Improve project-reader result when unresolved symbols are present

### DIFF
--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -153,6 +153,7 @@ export interface DeployStructure {
     versions?: VersionEntry // The VersionEntry for credentials.namespace on the selected API host if available
     feedback?: Feedback // The object to use for immediate communication to the user (e.g. for warnings and progress reports)
     error?: Error // Records an error in reading or preparing, or a terminal error in building; the structure should not be used
+    unresolvedVariables?: string[] // Variables that couldn't be resolved in project reading (error may be set also)
     webBuildError?: Error // Indicates an error in building the web component; the structure is usable but the failure should be reported
     webBuildResult?: string // activation id of remote build
     sequences?: ActionSpec[] // detected during action deployment and deferred until ordinary actions are deployed

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export {
 } from './credentials'
 export { cleanBucket, restore404Page, makeStorageClient } from './deploy-to-bucket'
 export { wskRequest, inBrowser, delay, writeSliceResult, getBestProjectName, isTextType, renamePackage, setInBrowserFlag, getExclusionList, isExcluded, 
-  SYSTEM_EXCLUDE_PATTERNS, getRuntimeForAction } from './util'
+  SYSTEM_EXCLUDE_PATTERNS, getRuntimeForAction, emptyStructure } from './util'
 export * from './runtimes'
 export { GithubDef, isGithubRef, parseGithubRef, fetchProject } from './github'
 export { deleteSlice } from './slice-reader'

--- a/src/util.ts
+++ b/src/util.ts
@@ -84,7 +84,11 @@ export async function loadProjectConfig(configFile: string, envPath: string, fil
       } else {
         err.message = `${errMsgPrefix}`
       }
-      return errorStructure(err)
+      const errans = errorStructure(err)
+      if (err.unresolved) {
+        errans.unresolvedVariables = err.unresolved
+      }
+      return errans
     }
   })
 }
@@ -793,7 +797,9 @@ export function substituteFromEnvAndFiles(input: string, envPath: string, projec
   }
   if (badVars.length > 0) {
     const formatted = "'" + badVars.join("', '") + "'"
-    throw new Error('The following substitutions could not be resolved: ' + formatted)
+    const toThrow =  new Error('The following substitutions could not be resolved: ' + formatted)
+    toThrow['unresolved'] = badVars
+    throw toThrow
   }
   if (warn) {
     feedback.warn("Using '${}' for dictionary substitution is now deprecated; use '$()'")


### PR DESCRIPTION
Mostly useful in support of the get-metadata command in the CLI