### PR TITLE
Support a build environment argument on project deploy

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -83,7 +83,7 @@ export function readPrepareAndBuild(path: string, owOptions: OWOptions, credenti
 export function readAndPrepare(path: string, owOptions: OWOptions, credentials: Credentials, persister: Persister,
   flags: Flags, runtimes: RuntimesConfig, userAgent?: string, feedback?: Feedback): Promise<DeployStructure> {
   const includer = makeIncluder(flags.include, flags.exclude)
-  return readProject(path, flags.env, includer, flags.remoteBuild, feedback, runtimes).then(spec => spec.error ? spec
+  return readProject(path, flags.env, flags.buildEnv, includer, flags.remoteBuild, feedback, runtimes).then(spec => spec.error ? spec
     : prepareToDeploy(spec, owOptions, credentials, persister, flags))
 }
 
@@ -105,12 +105,12 @@ export function deploy(todeploy: DeployStructure): Promise<DeployResponse> {
 }
 
 // Read the information contained in the project, initializing the DeployStructure
-export async function readProject(projectPath: string, envPath: string, includer: Includer, requestRemote: boolean,
+export async function readProject(projectPath: string, envPath: string, buildEnvPath: string, includer: Includer, requestRemote: boolean,
   feedback: Feedback = new DefaultFeedback(), runtimes: RuntimesConfig): Promise<DeployStructure> {
   debug('Starting readProject, projectPath=%s, envPath=%s', projectPath, envPath)
   let ans: DeployStructure
   try {
-    const topLevel = await readTopLevel(projectPath, envPath, includer, false, feedback)
+    const topLevel = await readTopLevel(projectPath, envPath, buildEnvPath, includer, false, feedback)
     const parts = await buildStructureParts(topLevel, runtimes)
     ans = assembleInitialStructure(parts)
   } catch (err) {
@@ -130,7 +130,7 @@ export async function readProject(projectPath: string, envPath: string, includer
       return errorStructure(new Error(`Project '${projectPath}' cannot be deployed from the cloud because it requires building`))
     }
     try {
-      const topLevel = await readTopLevel(projectPath, envPath, includer, true, feedback)
+      const topLevel = await readTopLevel(projectPath, envPath, buildEnvPath, includer, true, feedback)
       const parts = await buildStructureParts(topLevel, runtimes)
       ans = assembleInitialStructure(parts)
     } catch (err) {

--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -158,6 +158,7 @@ export interface DeployStructure {
     webBuildError?: Error // Indicates an error in building the web component; the structure is usable but the failure should be reported
     webBuildResult?: string // activation id of remote build
     sequences?: ActionSpec[] // detected during action deployment and deferred until ordinary actions are deployed
+    buildEnv?: Record<string,string> // Build time environment
 }
 
 // Structure declaring ownership of the targetNamespace by this project.  Ownership is recorded only locally (in the credential store)

--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -85,6 +85,7 @@ export interface Flags {
     incremental: boolean
     yarn: boolean
     env: string|undefined
+    buildEnv: string|undefined
     webLocal: string|undefined
     include: string|undefined
     exclude: string|undefined

--- a/src/project-reader.ts
+++ b/src/project-reader.ts
@@ -53,6 +53,9 @@ export async function readTopLevel(filePath: string, env: string, buildEnv: stri
   if (env && !fs.existsSync(env)) {
     throw new Error(`The specified environment file '${env}' does not exist`)
   }
+  if (buildEnv && !fs.existsSync(buildEnv)) {
+    throw new Error(`The specified environment file '${buildEnv}' does not exist`)
+  }
   let githubPath: string
   let reader: ProjectReader
   if (isGithubRef(filePath)) {

--- a/src/project-reader.ts
+++ b/src/project-reader.ts
@@ -35,6 +35,7 @@ interface TopLevel {
     packages: string
     config?: string
     env?: string
+    buildEnv?: string
     strays: string[]
     filePath: string
     githubPath: string
@@ -42,7 +43,7 @@ interface TopLevel {
     reader: ProjectReader
     feedback: Feedback
 }
-export async function readTopLevel(filePath: string, env: string, includer: Includer, mustBeLocal: boolean, feedback: Feedback): Promise<TopLevel> {
+export async function readTopLevel(filePath: string, env: string, buildEnv: string, includer: Includer, mustBeLocal: boolean, feedback: Feedback): Promise<TopLevel> {
   // The mustBeLocal arg is only important if the filePath denotes a github location.  In that case, a true value for
   // mustBeLocal causes the github contents to be fetched to a local cache and a FileReader is used.  A false value
   // causes a GithubReader to be used.
@@ -126,7 +127,7 @@ export async function readTopLevel(filePath: string, env: string, includer: Incl
       debug('github path was %s', githubPath)
       debug('filePath is %s', filePath)
     }
-    const ans = { web, packages, config, strays, filePath, env, githubPath, includer, reader, feedback }
+    const ans = { web, packages, config, strays, filePath, env, buildEnv, githubPath, includer, reader, feedback }
     debug('readTopLevel returning %O', ans)
     return ans
   })
@@ -135,8 +136,8 @@ export async function readTopLevel(filePath: string, env: string, includer: Incl
 // Probe the top level structure to obtain the major parts of the final config.  Spawn builders for those parts and
 // assemble a "Promise.all" for the combined work
 export async function buildStructureParts(topLevel: TopLevel, runtimes: RuntimesConfig): Promise<DeployStructure[]> {
-  const { web, packages, config, strays, filePath, env, githubPath, includer, reader, feedback } = topLevel
-  let configPart = await readConfig(config, env, filePath, includer, reader, feedback, runtimes)
+  const { web, packages, config, strays, filePath, env, buildEnv, githubPath, includer, reader, feedback } = topLevel
+  let configPart = await readConfig(config, env, buildEnv, filePath, includer, reader, feedback, runtimes)
   const deployerAnnotation = configPart.deployerAnnotation || await getDeployerAnnotation(filePath, githubPath)
   configPart = Object.assign(configPart, { strays, filePath, githubPath, includer, reader, feedback, deployerAnnotation })
   const displayName = getBestProjectName(configPart)
@@ -397,7 +398,7 @@ function duplicateName(actionName: string, formerUse: string, newUse: string) {
 }
 
 // Read the config file if present.  For convenience, the extra information not merged from elsewhere is tacked on here
-async function readConfig(configFile: string, envPath: string, filePath: string, includer: Includer, reader: ProjectReader,
+async function readConfig(configFile: string, envPath: string, buildEnvPath: string, filePath: string, includer: Includer, reader: ProjectReader,
   feedback: Feedback, runtimesConfig: RuntimesConfig): Promise<DeployStructure> {
   if (!configFile) {
     debug('No config file found')
@@ -405,7 +406,7 @@ async function readConfig(configFile: string, envPath: string, filePath: string,
     return Promise.resolve(ans)
   }
   debug('Reading config file')
-  return loadProjectConfig(configFile, envPath, filePath, reader, feedback, runtimesConfig).then(config => trimConfigWithIncluder(config, includer))
+  return loadProjectConfig(configFile, envPath, buildEnvPath, filePath, reader, feedback, runtimesConfig).then(config => trimConfigWithIncluder(config, includer))
     .catch(err => errorStructure(err))
 }
 

--- a/tests/unit/util.test.ts
+++ b/tests/unit/util.test.ts
@@ -35,7 +35,7 @@ describe('test validation of loading project configuration', () => {
         return Promise.resolve('')
       }
     }
-    const result = await loadProjectConfig('project.yml', '', '', (reader as unknown) as ProjectReader, null, {} as RuntimesConfig)
+    const result = await loadProjectConfig('project.yml', '', '', '', (reader as unknown) as ProjectReader, null, {} as RuntimesConfig)
     let expectedText
     if (process.version.startsWith('v16')) {
       expectedText = `Cannot read properties of undefined (reading 'slice')`
@@ -50,7 +50,7 @@ describe('test validation of loading project configuration', () => {
         return Promise.resolve('packages:')
       }
     }
-    const result = await loadProjectConfig('project.yml', '', '', (reader as unknown) as ProjectReader, null, {} as RuntimesConfig)
+    const result = await loadProjectConfig('project.yml', '', '', '', (reader as unknown) as ProjectReader, null, {} as RuntimesConfig)
     expect(result).toEqual({packages: null})
   })
 })


### PR DESCRIPTION
This is in support of a visible `--build-env` flag on the Nimbella CLI.

The build environment is specified via a file, similar to `--env`.  However, the variables defined there do not modify `project .yml` but rather show up in the process environment of any builds that are run.

This was not so essential for local builds because the developer had control over that process environment.   However, it is important for remote builds where there is no other way of affecting the process environment during a build.