### PR TITLE
Fix remote build env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {

--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -141,6 +141,7 @@ export interface DeployStructure {
     credentials?: Credentials // The full credentials for the deployment (consistent with targetNamespace if one was specified)
     flags? : Flags // options typically specified on the command line
     deployerAnnotation?: DeployerAnnotation // The deployer annotation to use (with the digest undefined, as it varies)
+    buildEnv?: Record<string,string> // Build time environment
     // The following fields are never permitted in project.yml but are always added internally
     webBuild?: string // Type of build (build.sh or package.json) to apply to the web directory
     sharedBuilds?: BuildTable // The build table for this project, populated as shared builds are initiated
@@ -158,7 +159,6 @@ export interface DeployStructure {
     webBuildError?: Error // Indicates an error in building the web component; the structure is usable but the failure should be reported
     webBuildResult?: string // activation id of remote build
     sequences?: ActionSpec[] // detected during action deployment and deferred until ordinary actions are deployed
-    buildEnv?: Record<string,string> // Build time environment
 }
 
 // Structure declaring ownership of the targetNamespace by this project.  Ownership is recorded only locally (in the credential store)

--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -602,10 +602,11 @@ async function doRemoteWebBuild(project: DeployStructure, runtimes: RuntimesConf
 // out as a project.yml and also the path to the action file or directory, for zipping.
 function makeConfigFromActionSpec(action: ActionSpec, spec: DeployStructure, pkgName: string): DeployStructure {
   debug('converting action spec to sliced project.yml: %O', action)
-  const { targetNamespace, cleanNamespace, parameters, credentials, flags, deployerAnnotation } = spec
+  const { targetNamespace, cleanNamespace, parameters, credentials, flags, deployerAnnotation, buildEnv } = spec
   flags.remoteBuild = false
+  flags.buildEnv = undefined
   const { name, runtime, main, binary, zipped, web, webSecure, annotations, environment, limits, clean } = action
-  const newSpec = { targetNamespace, cleanNamespace, parameters, credentials, flags, deployerAnnotation, slice: true } as DeployStructure
+  const newSpec = { targetNamespace, cleanNamespace, parameters, credentials, flags, deployerAnnotation, buildEnv, slice: true } as DeployStructure
   const newAction = {
     name,
     runtime,
@@ -632,9 +633,10 @@ function makeConfigFromActionSpec(action: ActionSpec, spec: DeployStructure, pkg
 // included in the project slice separately
 function makeConfigFromWebSpec(project: DeployStructure): DeployStructure {
   debug('converting project spec to sliced project.yml for web building')
-  const { targetNamespace, cleanNamespace, bucket, credentials, flags, deployerAnnotation } = project
+  const { targetNamespace, cleanNamespace, bucket, credentials, flags, deployerAnnotation, buildEnv } = project
   flags.remoteBuild = false
-  return removeUndefined({ targetNamespace, cleanNamespace, bucket, credentials, flags, deployerAnnotation, slice: true })
+  flags.buildEnv = undefined
+  return removeUndefined({ targetNamespace, cleanNamespace, bucket, credentials, flags, deployerAnnotation, buildEnv, slice: true })
 }
 
 // Remove undefined fields from object (mutates object but returns it as well)

--- a/src/project-reader.ts
+++ b/src/project-reader.ts
@@ -175,6 +175,7 @@ export function assembleInitialStructure(parts: DeployStructure[]): DeployStruct
       }
     })
   }
+  debug('Result of assembly: %O', configPart)
   return configPart
 }
 
@@ -409,8 +410,10 @@ async function readConfig(configFile: string, envPath: string, buildEnvPath: str
     return Promise.resolve(ans)
   }
   debug('Reading config file')
-  return loadProjectConfig(configFile, envPath, buildEnvPath, filePath, reader, feedback, runtimesConfig).then(config => trimConfigWithIncluder(config, includer))
+  const config = loadProjectConfig(configFile, envPath, buildEnvPath, filePath, reader, feedback, runtimesConfig).then(config => trimConfigWithIncluder(config, includer))
     .catch(err => errorStructure(err))
+  debug('Config contents: %O', config)
+  return config
 }
 
 // Given a DeployStructure with web and package sections, trim those sections according to the rules of an Includer

--- a/src/util.ts
+++ b/src/util.ts
@@ -333,6 +333,7 @@ export function validateDeployConfig(arg: any, runtimesConfig: RuntimesConfig): 
       case 'credentials':
       case 'flags':
       case 'deployerAnnotation':
+      case 'buildEnv':
         if (slice) continue
       // In a slice we accept these without further validation; otherwise, they are illegal
       // Otherwise, fall through


### PR DESCRIPTION
There were some bad interactions between --build-env and --remote-build.  

1.  The parsed build env was not being included in the slice.
2. Once that was fixed, the validator at the remote end was rejecting the field because it was not classified as legal in a slice.