### PR TITLE
Don't fail validation when no RuntimesConfig

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -466,7 +466,7 @@ function validateActionSpec(arg: Record<string, any>, runtimesConfig: RuntimesCo
         if (!(typeof arg[item] === 'string')) {
           return `'${item}' member of an 'action' must be a string`
         }
-        if (item === 'runtime' && !isValidRuntime(runtimesConfig, arg[item])) {
+        if (item === 'runtime' && Object.keys(runtimesConfig).length > 0 && !isValidRuntime(runtimesConfig, arg[item])) {
           return `'${arg[item]}' is not a valid runtime value`
         }
         break


### PR DESCRIPTION
This relaxation allows projects to be read (including `project.yml`) when there are runtime declarations in `project.yml` but the actual `RuntimesConfig` wasn't read.  There are valid cases for this when the caller has no credential store and no API host in the environment but is just inspecting a project.   For example, in the CLI, `project get-metadata` passes in an empty `RuntimesConfig`.  It is true that invalid runtimes may be accepted in that use-case (only).