### PR TITLE
Declare JSON flag explicitly in Flags type

### DIFF
--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -90,6 +90,7 @@ export interface Flags {
     include: string|undefined
     exclude: string|undefined
     remoteBuild: boolean
+    json: boolean
 }
 
 // Provides the status of a shared build


### PR DESCRIPTION
Now that the --json flag is global in the CLI, it is needed in the internal `Flags` type, which is offered by the deployer.   While it's true that the deployer itself does not consume this flag, many of the flags in `Flags` _are_ meaningful to the deployer and there is not otherwise a need for a separate CLI-only flags object.  So it is consistent with the overall design to place the --json flag in `Flags`.