### PR TITLE
Interpret main: '' as if main were omitted.

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -472,14 +472,15 @@ function encodeParameters(normalParms: openwhisk.Dict, envParms: openwhisk.Dict)
 
 // Construct the Action.Exec struct from the deployment configuration values.
 export function calculateActionExec(action: ActionSpec, code: string): Exec {
+  const main = action.main ? action.main : undefined // '' is falsey but won't be recognized as such by OW
   if (action.docker) {
-    return { code, binary: action.binary, kind: 'blackbox', image: action.docker, main: action.main }
+    return { code, binary: action.binary, kind: 'blackbox', image: action.docker, main }
   }
 
-  return { code, binary: action.binary, kind: action.runtime, main: action.main }
+  return { code, binary: action.binary, kind: action.runtime, main }
 }
 
-// Deploy an action when the code has already been read from a file or constructed programmatically or when the
+// Deploy an action when the code has already been read from a() file or constructed programmatically or when the
 // action is a sequence (Sequence passed in lieu of code).
 async function deployActionFromCodeOrSequence(action: ActionSpec, spec: DeployStructure,
   code: string, sequence: openwhisk.Sequence, pkgIsClean: boolean): Promise<DeployResponse> {


### PR DESCRIPTION
In `nim project create` we generate a `project.yml` with all defaults for the developer to expand upon later if needed.   For the `actions[] .main`  member, the natural default is `''`.   Although Javascript recognizes `''` as a falsey value, this is not universal across languages.   The controller will incorporate a `main` with an empty string value as if that were the programmer's intent, whereas the intent was to omit `main`.   This small adjustment to the deployer ensures that `main: ''` is interpreted as if `main` were omitted.