### PR TITLE
Punt in readProject once a bad config is found

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -119,6 +119,12 @@ export async function readProject(projectPath: string, envPath: string, buildEnv
   } catch (err) {
     return errorStructure(err)
   }
+  if (ans.error) {
+    // Remaining steps are treacherous if there was an error detected in the config. We don't use the
+    // errorStructure return for that case, because we need to support get-metadata, which wants a config
+    // even if erroneous.  However, any other uses are going to fail.
+    return ans
+  }
   debug('evaluating the just-read project: %O', ans)
   let needsLocalBuilds: boolean
   try {


### PR DESCRIPTION
It was found that the combination of unresolved variables in `project.yml` and the use of flags that cause more analysis of the config (e.g. `--remote-build`) would cause a TypeError to be reported instead of the more useful message about the unresolved variables.   This is fixed here.