### PR TITLE
Fix bug: global environment lost on remote build

### DIFF
--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -599,11 +599,11 @@ async function doRemoteWebBuild(project: DeployStructure, runtimes: RuntimesConf
 // out as a project.yml and also the path to the action file or directory, for zipping.
 function makeConfigFromActionSpec(action: ActionSpec, spec: DeployStructure, pkgName: string): DeployStructure {
   debug('converting action spec to sliced project.yml: %O', action)
-  const { targetNamespace, cleanNamespace, parameters, credentials, flags, deployerAnnotation, buildEnv } = spec
+  const { targetNamespace, cleanNamespace, parameters, environment: globalEnv, credentials, flags, deployerAnnotation, buildEnv } = spec
   flags.remoteBuild = false
   flags.buildEnv = undefined
   const { name, runtime, main, binary, zipped, web, webSecure, annotations, environment, limits, clean } = action
-  const newSpec = { targetNamespace, cleanNamespace, parameters, credentials, flags, deployerAnnotation, buildEnv, slice: true } as DeployStructure
+  const newSpec = { targetNamespace, cleanNamespace, parameters, environment: globalEnv, credentials, flags, deployerAnnotation, buildEnv, slice: true } as DeployStructure
   const newAction = {
     name,
     runtime,


### PR DESCRIPTION
A small bug in `makeConfigFromActionSpec` had a large consequence, which is that a top level `environment` clause was ineffective in combination with `--remote-build`.   A top-level `parameters` clause was being handled.   Fixed here.