### PR TITLE
In a slice build, take the API host from the environment (if available)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "3.1.14",
+  "version": "3.1.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "3.1.14",
+  "version": "3.1.15",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -204,6 +204,11 @@ export async function prepareToDeploy(inputSpec: DeployStructure, owOptions: OWO
   if (inputSpec.slice) {
     debug('Retrieving credentials and flags from spec for slice')
     credentials = inputSpec.credentials
+    // The API host in the slice spec may represent a proxy and hence not be the real intended host.
+    // If __OW_API_HOST is set, it is more trustworthy.
+    if (process.env.__OW_API_HOST) {
+      credentials.ow.apihost = process.env.__OW_API_HOST
+    }
     flags = inputSpec.flags
   }
   // 1.  Acquire credentials if not already present


### PR DESCRIPTION
A slice build normally goes to the provided `project.yml` (which contains credentials) to get the target API host.

But, in a runtime container, a more reliable source of information exists: the __OW_API_HOST environment variable.
This is just about always set by the invoker and represent the cluster that the remote build action is running on.

While the API host passed in the credentials is _usually_ reliable, it could represent a proxy host rather than the intended target.