### PR TITLE
Look for API host both in __OW and in savedOW

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -208,6 +208,8 @@ export async function prepareToDeploy(inputSpec: DeployStructure, owOptions: OWO
     // If __OW_API_HOST is set, it is more trustworthy.
     if (process.env.__OW_API_HOST) {
       credentials.ow.apihost = process.env.__OW_API_HOST
+    } else if (process.env.savedOW_API_HOST) {
+      credentials.ow.apihost = process.env.savedOW_API_HOST
     }
     flags = inputSpec.flags
   }


### PR DESCRIPTION
A recent commit was attempting to use information from the environment when a slice deploy is done inside a runtime container.   But, `nim` will have stashed the value during `initializeAPI`.   So, we have to look in the stashed place also.