### PR TITLE
Refactor package deploy. Do early if remote build

### DIFF
--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -44,6 +44,7 @@ export interface PackageSpec {
     environment?: Dict // Bound parameters for all actions in the package, destined to go in the environment of each action
     clean?: boolean // Indicates that the package is to be deleted (with its contained actions) before deployment
     web?: any // like 'web' on an action but affects all actions of the package that don't redeclare the flag
+    deployedDuringBuild?: boolean // set when the package was deployed early because some builds were remote
 }
 
 // Describes one action

--- a/src/util.ts
+++ b/src/util.ts
@@ -302,7 +302,7 @@ export function validateDeployConfig(arg: any, runtimesConfig: RuntimesConfig): 
           return 'packages member must be an array'
         }
         for (const subitem of arg[item]) {
-          const pkgError = validatePackageSpec(subitem, runtimesConfig)
+          const pkgError = validatePackageSpec(subitem, runtimesConfig, slice)
           if (pkgError) {
             return pkgError
           }
@@ -407,7 +407,7 @@ function validateWebResource(arg: Record<string, any>): string {
 }
 
 // Validator for a PackageSpec
-function validatePackageSpec(arg: Record<string, any>, runtimesConfig: RuntimesConfig): string {
+function validatePackageSpec(arg: Record<string, any>, runtimesConfig: RuntimesConfig, slice: boolean): string {
   const isDefault = arg.name === 'default'
   for (const item in arg) {
     if (!arg[item]) continue
@@ -447,6 +447,8 @@ function validatePackageSpec(arg: Record<string, any>, runtimesConfig: RuntimesC
       if (isDefault && Object.keys(arg[item]).length > 0) {
         return `'${item}' must be absent or empty for the default package`
       }
+    } else if (item === 'deployedDuringBuild' && slice) {
+      continue
     } else {
       return `Invalid key '${item}' found in 'package' in project.yml`
     }


### PR DESCRIPTION
Addresses issue #60.

This change
1. Adds a field to the PackageSpec, stating whether it was already deployed.
2. Changes the deploy logic when there are any remote builds in a package.   The package is deployed before starting the remote builds.
3. Slice deploys no longer deploy the enclosing package, just the action they've been asked to deploy. 

The net result is to eliminate the redundant deployment of the package in every remote build in favor of deploying it only once.   This is not done just (or even primarily) for efficiency.   Rather, as the associated issue points out, the deploys of the package are unsynchronized and hence can conflict, causing 409 errors.   The net of this change is to fix that.