### PR TITLE
Improvements to slice deploys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "3.1.17",
+  "version": "3.1.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "3.1.17",
+  "version": "3.1.18",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {

--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -251,6 +251,7 @@ export interface DeployerAnnotation {
     projectPath: string
     user: string
     zipped?: boolean
+    newSliceHandling?: boolean
 }
 
 // Grouping for OW Options that can be specified on the command line or by caller; also part of credential lookup response

--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -94,6 +94,7 @@ async function buildActionsOfPackage(pkg: PackageSpec, spec: DeployStructure, ru
       throw pkgResult.failures[0]
     }
     pkg.deployedDuringBuild = true
+    spec.deployerAnnotation.newSliceHandling = true
   }  
   // Now run all the builds in this package  
   const actionMap = mapActions(pkg.actions)
@@ -633,6 +634,7 @@ function makeConfigFromActionSpec(action: ActionSpec, spec: DeployStructure, pkg
   removeUndefined(newAction)
   const pkg = spec.packages.find(pkg => pkg.name === pkgName)
   pkg.actions = [newAction]
+  pkg.deployedDuringBuild = false
   newSpec.packages = [pkg]
   return newSpec
 }


### PR DESCRIPTION
Suppression of package deploys in slice deploys was done in a way that inhibits mix-and-match (where the initiating 'nim' and the 'nim' in the runtime container are at different versions).   This change is intended to improve the flexibility.

Issue #60, follow-up to PR #61.