### PR TITLE
Fix isValidRuntime utility and its associated test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "3.1.20",
+  "version": "3.1.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-deployer",
-      "version": "3.1.20",
+      "version": "3.1.21",
       "license": "Apache-2.0",
       "dependencies": {
         "@nimbella/sdk": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "3.1.20",
+  "version": "3.1.21",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -86,9 +86,25 @@ export function fileExtensionForRuntime(runtime: RuntimeKind, isBinaryExtension:
 // Does the runtime kind exist in the platform config?
 export function isValidRuntime(runtimes: RuntimesConfig, kind: RuntimeKind): boolean {
   debug_log(`isValidRuntime: runtimes (${runtimes}) kind (${kind})`)
-  const [_, version] = kind.split(':')
-  //const images = runtimes[label] ?? []
-  return Object.values(runtimes).some(images => images.some(i => version === 'default' ? i.default : i.kind === kind))
+  let exactMatch = true
+  if (kind.endsWith(':default')) {
+    kind = kind.split(':')[0] + ':'
+    exactMatch = false
+  }
+  debug_log('searching')
+  for (const runtimeArray of Object.values(runtimes)) {
+    for (const runtime of runtimeArray) {
+      if (exactMatch && kind === runtime.kind) {
+        debug_log(`${kind}===${runtime.kind}`)
+        return true
+      } else if (!exactMatch && runtime.kind.startsWith(kind) && runtime.default) {
+        debug_log(`${runtime.kind} starts with ${kind} and is the default`)
+        return true
+      }
+      debug_log(`no match on ${runtime.kind}`)
+    }
+  }
+  return false
 }
 
 // Find the default runtime for a language

--- a/tests/unit/runtimes.test.ts
+++ b/tests/unit/runtimes.test.ts
@@ -135,7 +135,7 @@ describe('test checking valid runtimes', () => {
   test('should find valid runtimes with default version', () => {
     const runtimes: RuntimesConfig = {
       nodejs: [{ "kind": "nodejs:10", default: true }],
-      python: [{ "kind": "python-ai:10", default: true }]
+      python: [{ "kind": "python:10", default: true }]
     }
     expect(isValidRuntime(runtimes, 'nodejs:default')).toEqual(true)
     expect(isValidRuntime(runtimes, 'python:default')).toEqual(true)


### PR DESCRIPTION
This PR fixes two bugs in the runtimes utility library (`runtimes.ts`) which were mutually cancelling.

1.   The `isValidRuntime` utility was returning `true` for anything ending in `:default`  if there were any default runtimes at all, rather than also checking the appropriate stem match for the specific runtime being interrogated.   So, for example, no matter what was in the actual response from the controller it would say that `ruby:default` was present.
2. The test for this case was flawed.   It used an interrogation that should have returned `false` but was expecting `true`. 

Since this change is immediately needed in the CLI the PR also increments the patch version preparatory to releasing ASAP.