### PR TITLE
Fix bug in handling of ./ in include files

### DIFF
--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -184,11 +184,14 @@ function makeLocal(reader: ProjectReader, ...paths: string[]): string {
 async function processIncludeFileItems(items: string[], dirPath: string, reader: ProjectReader): Promise<string[][]> {
   const complex: Promise<string[][]>[] = []
   const simple: string[][] = []
-  for (const item of items) {
+  for (let item of items) {
     if (!item || item.length === 0) {
       continue
     }
     debug('processing include item %s', item)
+    if (item.startsWith('./') || item.startsWith('.\\')) {
+      item = item.slice(2)
+    }
     let oldPath = path.isAbsolute(item) ? item : joinAndNormalize(dirPath, item)
     if (oldPath.endsWith('/') || oldPath.endsWith('\\')) {
       oldPath = oldPath.slice(0, -1)


### PR DESCRIPTION
The complex logic in `processIncludeFileItems` gets confused by an in initial `./` on include file items.   While the logic probably deserves to be simplified, the present fix just anticipates the problem by removing leading `./` characters before anything else.

A more satisfying simplification of this logic is likely when we make absolute paths and references outside the project illegal.   Such references already break deploy from github and remote build so eliminating them is a likely future change.