### PR TITLE
Fix omissions in incremental deploy digest logic

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1078,8 +1078,10 @@ export function digestPackage(pkg: PackageSpec): string {
   const hash = crypto.createHash('sha256')
   digestBoolean(hash, pkg.shared)
   digestBoolean(hash, pkg.clean)
+  digestBoolean(hash, pkg.web)
   digestDictionary(hash, pkg.annotations)
   digestDictionary(hash, pkg.parameters)
+  digestDictionary(hash, pkg.environment)
   for (const action of pkg.actions || []) {
     hash.update(action.name)
   }
@@ -1088,6 +1090,14 @@ export function digestPackage(pkg: PackageSpec): string {
 
 function digestBoolean(hash: crypto.Hash, toDigest: boolean) {
   hash.update(String(!!toDigest))
+}
+
+function digestStringArray(hash: crypto.Hash, toDigest: string[]) {
+  if (toDigest) {
+    for (const value of toDigest) {
+      hash.update(value) 
+    }
+  }
 }
 
 function digestDictionary(hash: crypto.Hash, toDigest: Record<string, any>) {
@@ -1124,7 +1134,9 @@ export function digestAction(action: ActionSpec, code: string): string {
   hash.update(String(action.webSecure))
   digestDictionary(hash, action.annotations)
   digestDictionary(hash, action.parameters)
+  digestDictionary(hash, action.environment)
   digestDictionary(hash, action.limits)
+  digestStringArray(hash, action.sequence)  
   hash.update(code)
   if (action.main) {
     hash.update(action.main)


### PR DESCRIPTION
Several fields were added to ActionSpec and PackageSpec since incremental deploy was coded.   Most notably, the `environment` property has been added to both but there were miscellaneous other additions.   Changes to the environment property were not affecting the digests used to decide whether to deploy an action, and so, `nim project watch` would appear to misbehave (not redeploy the action) after such changes.

After updating the digest calculation to take into account the additions, this symptom went away.

I'm leaving for another day a way to automate the underlying issue out of existence.   You can't just iterate over the own properties of the two kinds of object and digest everything because there are fields that are volatile and used, essentially, for bookkeeping.    So, if you did that, the digests would never stabilize and the deploy would no longer be incremental.   Perhaps we should use a blacklist approach (digest everything _except_ certain fields, which are listed in some constant right alongside the declaration of the types.   Or something.