### PR TITLE
Fix combination of default package and remote build

### DIFF
--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -87,7 +87,7 @@ export function buildAllActions(spec: DeployStructure, runtimes: RuntimesConfig)
 // Build the actions of a package, returning an updated PackageSpec or undefined if nothing got built
 async function buildActionsOfPackage(pkg: PackageSpec, spec: DeployStructure, runtimes: RuntimesConfig): Promise<PackageSpec> {
   // Determine if any remote builds exist in this package.  If so, we have to deploy the package before doing the builds.
-  let mustDeployPackage = pkg.actions?.some(action => action.build === 'remote' || action.build === 'remote-default')
+  let mustDeployPackage = pkg.name !== 'default' && pkg.actions?.some(action => action.build === 'remote' || action.build === 'remote-default')
   if (mustDeployPackage) {
     const pkgResult = await onlyDeployPackage(pkg, spec)
     if (pkgResult.failures.length > 0) {


### PR DESCRIPTION
A bug was introduced in release 3.1.18 (which contained the fix for issue #60).  When a build is remote and the default package is being used, the local deployer tries to deploy 'default' as a package before spawning the remote build.   Because the --remote-build flag is advisory, you only see the error when there is "something to build" (e.g. a build.sh or package.json).   Otherwise, deployment is local and behaves correctly.  This was not caught by the Nimbella CLI regression tests because none of those use the combination of a default package and a "real" remote build.

This PR fixes the bug.