### PR TITLE
Stricter rules for .include files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "3.1.22",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-deployer",
-      "version": "3.1.22",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@nimbella/sdk": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "3.1.22",
+  "version": "4.0.0",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
This is the first step in implementing issue #69.   It changes the checking of `.include` files to prohibit arbitrary references.   It is still possible to refer to the directory hosting the `.include`, the directory `lib` off the project root, and any subdirectories of those directories.   All other references are illegal.