### PR TITLE
Build lib directory and ship it to remote builds

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -150,9 +150,11 @@ export async function readProject(projectPath: string, envPath: string, buildEnv
 }
 
 // 'Build' the project by running the "finder builder" steps in
-// 1.  the 'lib' directory if found
+// 1.  the 'lib' directory if found and if building it is appropriate
 // 2.  each action-as-directory
 // 3.  the 'web' directory if found
+// Steps 2 and 3 can be done in parallel but step 1 must complete before the
+// others are started.
 export async function buildProject(project: DeployStructure, runtimes: RuntimesConfig): Promise<DeployStructure> {
   debug('Starting buildProject with spec %O', project)
   let webPromise: Promise<WebResource[]|Error>

--- a/src/api.ts
+++ b/src/api.ts
@@ -21,7 +21,7 @@ import {
   checkBuildingRequirements, errorStructure, getBestProjectName, inBrowser
 } from './util'
 import { openBucketClient } from './deploy-to-bucket'
-import { buildAllActions, buildWeb } from './finder-builder'
+import { buildAllActions, buildWeb, maybeBuildLib } from './finder-builder'
 import openwhisk = require('openwhisk')
 import { getCredentialsForNamespace, getCredentials, Persister, recordNamespaceOwnership } from './credentials'
 import { makeIncluder } from './includer'
@@ -149,11 +149,21 @@ export async function readProject(projectPath: string, envPath: string, buildEnv
   return ans
 }
 
-// 'Build' the project by running the "finder builder" steps in each action-as-directory and in the web directory
+// 'Build' the project by running the "finder builder" steps in
+// 1.  the 'lib' directory if found
+// 2.  each action-as-directory
+// 3.  the 'web' directory if found
 export async function buildProject(project: DeployStructure, runtimes: RuntimesConfig): Promise<DeployStructure> {
   debug('Starting buildProject with spec %O', project)
   let webPromise: Promise<WebResource[]|Error>
   project.sharedBuilds = { }
+  if (project.libBuild) {
+    try {
+      await maybeBuildLib(project)
+    } catch (err) {
+      return errorStructure(err)
+    }
+  }
   if (project.webBuild) {
     webPromise = buildWeb(project, runtimes).catch(err => Promise.resolve(err))
   }

--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -146,6 +146,7 @@ export interface DeployStructure {
     buildEnv?: Record<string,string> // Build time environment
     // The following fields are never permitted in project.yml but are always added internally
     webBuild?: string // Type of build (build.sh or package.json) to apply to the web directory
+    libBuild?: string // Type of build (build.sh or package.json) to apply to the lib directory
     sharedBuilds?: BuildTable // The build table for this project, populated as shared builds are initiated
     strays?: string[] // files or directories found in the project that don't fit the model, not necessarily an error
     filePath?: string // The location of the project on disk

--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -534,7 +534,7 @@ function checkForNodeModules(items: string[]) {
 
 // Check that all include file items resolve to "legal" places (inside the directory being built or a 'lib' directory at project root)
 // Returns an error message if an illegal item is found, else the empty string.
-function checkIncludeItems(items: string[], web: boolean): string {
+export function checkIncludeItems(items: string[], web: boolean): string {
   const legalDots = web ? '../lib' : '../../../lib'
   for (const item of items) {
     if (!item || item.length === 0) {
@@ -547,6 +547,7 @@ function checkIncludeItems(items: string[], web: boolean): string {
       return `Illegal use of '..' in an '.include' file`
     }
   }
+  return ""
 }
 
 // Check the .include file, if any, for illegal inclusions.   This permits

--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -51,7 +51,7 @@ const CANNED_REMOTE_BUILD = `#!/bin/bash
 
 // Determine the build type for an action that is defined as a directory
 export function getBuildForAction(filepath: string, reader: ProjectReader): Promise<string> {
-  return readDirectory(filepath, reader).then(items => findSpecialFile(items, filepath, true))
+  return readDirectory(filepath, reader).then(items => findSpecialFile(items, filepath, true, false))
 }
 
 // Build all the actions in an array of PackageSpecs, returning a new array of PackageSpecs.  We try to return
@@ -308,7 +308,7 @@ function outOfLineBuilder(filepath: string, displayPath: string, sharedBuilds: B
     } else if (stat.isDirectory) {
       // Look in the directory to find build to run
       return readDirectory(redirected, reader).then(items => {
-        const special = findSpecialFile(items, filepath, isAction)
+        const special = findSpecialFile(items, filepath, isAction, false)
         let build: () => Promise<any>
         const cwd = makeLocal(reader, redirected)
         switch (special) {
@@ -394,12 +394,57 @@ function isSharedBuild(items: PathKind[]): boolean {
   return shared
 }
 
-// Determine the build step for the web directory or return undefined if there isn't one
-export function getBuildForWeb(filepath: string, reader: ProjectReader): Promise<string> {
+// Determine the build step for the lib or web directory or return undefined if there isn't one
+export function getBuildForLibOrWeb(filepath: string, reader: ProjectReader, lib: boolean): Promise<string> {
   if (!filepath) {
     return Promise.resolve(undefined)
   }
-  return readDirectory(filepath, reader).then(items => findSpecialFile(items, filepath, false))
+  return readDirectory(filepath, reader).then(items => findSpecialFile(items, filepath, false, lib))
+}
+
+// Build the lib directory only if appropriate.  It is appropriate to build it
+// if (1) we are deploying a slice ("already running remotely") or (2) there is
+// some action (or web content) that will be deployed locally.  In other words,
+// we do _not_ build lib in the case where this deployment is running locally but
+// everything will in fact be deployed remotely.
+export async function maybeBuildLib(spec: DeployStructure): Promise<void> {
+  function isRemote(build: string): boolean {
+    return build === 'remote' || build === 'remote-default'
+  }
+  let shouldBuild = spec.slice || (spec.webBuild && !isRemote(spec.webBuild))
+  if (!shouldBuild && spec.packages) {
+    pkgLoop: for (const pkg of spec.packages) {
+      if (pkg.actions) {
+        for (const action of pkg.actions) {
+          shouldBuild = action.build && !isRemote(action.build)
+          if (shouldBuild) {
+            break pkgLoop
+          }
+        }
+      }
+    }
+  }
+  if (shouldBuild) {
+    let scriptPath: string
+    const displayPath = path.join(getBestProjectName(spec), 'lib')
+    const { reader, flags, feedback, sharedBuilds, slice, buildEnv } = spec
+    switch (spec.libBuild) {
+      case 'build.sh':
+        scriptPath = makeLocal(reader, 'lib')
+        return scriptBuilder('./build.sh', scriptPath, displayPath, flags, buildEnv, slice, feedback)
+      case 'build.cmd':
+        scriptPath = makeLocal(reader, 'lib')
+        return scriptBuilder('build.cmd', scriptPath, displayPath, flags, buildEnv, slice, feedback)
+      case '.build':
+        // Does its own localizing
+        return outOfLineBuilder('lib', displayPath, sharedBuilds, false, flags, buildEnv, slice, reader, feedback)
+      case 'package.json':
+        scriptPath = makeLocal(reader, 'lib')
+        return npmBuilder(scriptPath, displayPath, flags, buildEnv, slice, feedback)
+      default:
+        throw new Error('Unknown or inappropriate build type for lib directory: ' + spec.libBuild)
+    }
+  }
 }
 
 export function buildWeb(spec: DeployStructure, runtimes: RuntimesConfig): Promise<WebResource[]> {
@@ -542,6 +587,10 @@ async function doRemoteActionBuild(action: ActionSpec, project: DeployStructure,
     debug('Setting runtime to %s for remote build', runtime)
     action.runtime = runtime
   }
+  // Add 'lib' if it is present
+  if (project.libBuild) {
+    await appendLibToZip(zip, 'lib', project.reader)
+  }
   // Add the project.yml
   const spec = makeConfigFromActionSpec(action, project, pkgName)
   debug('converting slice spec to YAML: %O', spec)
@@ -594,6 +643,15 @@ async function appendToZip(zip: archiver.Archiver, actionPath: string, reader: P
   return agreeOnRuntime(analyzeForRuntime, runtimes)
 }
 
+// A simplified version of appendToZip for adding secondary directories (currently 'lib') to the slice
+async function appendLibToZip(zip: archiver.Archiver, path: string, reader: ProjectReader) {
+    zipDebug('getting contents of directory %s for remote build slice', path)
+    const files = await promiseFilesAndFilterFiles(path, reader)
+    for (const file of files) {
+      await appendAndCheck(zip, file, path, reader)
+    }
+}
+
 // Append a path known to be a file to the in-memory zip, checking for excessive size and issuing debug if requested.
 async function appendAndCheck(zip: archiver.Archiver, file: string, actionPath: string, reader: ProjectReader) {
   const contents = await reader.readFileContents(file)
@@ -617,6 +675,10 @@ async function doRemoteWebBuild(project: DeployStructure, runtimes: RuntimesConf
   const spec = makeConfigFromWebSpec(project)
   // Zip the web path
   await appendToZip(zip, 'web', project.reader, '', runtimes)
+  // Add 'lib' if it is present
+  if (project.libBuild) {
+    await appendLibToZip(zip, 'lib', project.reader)
+  }
   // Add the project.yml
   const config = yaml.safeDump(spec)
   zip.append(config, { name: 'project.yml' })
@@ -821,7 +883,7 @@ function readDirectory(filepath: string, reader: ProjectReader): Promise<PathKin
   return reader.readdir(filepath).then(filterFiles)
 }
 
-// Find the "dominant" special file in a collection of files within an action or web directory, while checking for some errors
+// Find the "dominant" special file in a collection of files within an action, web, or lib directory, while checking for some errors
 // The dominance order is build.[sh|cmd] > .build > package.json > .include > none-of-these (returns 'identify' since 'building' will
 //   then start by identifying files)
 // Errors detected are:
@@ -830,7 +892,8 @@ function readDirectory(filepath: string, reader: ProjectReader): Promise<PathKin
 //    build.cmd but no build.sh on a macos or linux system
 //    .ignore when there is also .include
 //    no files in directory (or only an .ignore file); actions only (web directory is permitted to be empty)
-function findSpecialFile(items: PathKind[], filepath: string, isAction: boolean): string {
+//    in a 'lib' directory .include, .ignore, and .build are illegal
+function findSpecialFile(items: PathKind[], filepath: string, isAction: boolean, isLib: boolean): string {
   const files = items.filter(item => !item.isDirectory)
   let buildDotSh = false; let buildDotCmd = false; let npm = false; let include = false; let dotBuild = false; let ignore = false
   for (const file of files) {
@@ -855,6 +918,8 @@ function findSpecialFile(items: PathKind[], filepath: string, isAction: boolean)
     throw new Error(`In ${filepath}: '.include' (or '.source') and '.ignore' may not both be present`)
   } else if (isAction && (files.length === 0 || (ignore && files.length === 1))) {
     throw new Error(`Action directory ${filepath} has no files`)
+  } else if (isLib && (include || ignore || dotBuild)) {
+    throw new Error(`'.include', '.ignore', and '.build' are not supported in the 'lib' directory`)
   }
   if (process.platform === 'win32') {
     if (buildDotSh && !buildDotCmd) {
@@ -895,7 +960,7 @@ function singleFileBuilder(action: ActionSpec, file: string, runtimes: RuntimesC
 // 2.  If there is a runtime provided in the ActionSpec we leave it there.  Otherwise, we scan the files to see if we
 //     can decide on an unambiguous runtime value.  If we can't, it's an error.
 // 3.  Use archiver to zip the items individually, according to the rules that
-//     - an item is renamed to the basename of the item if it contains .. or is an absolute path
+//     - an item is renamed to the basename of the item if it contains ..
 //     - an item is zipped as is otherwise
 //     - directories are zipped recursively
 // 4.  Return an ActionSpec promise describing the result.

--- a/src/util.ts
+++ b/src/util.ts
@@ -101,7 +101,7 @@ export async function loadProjectConfig(configFile: string, envPath: string, bui
 }
 
 // Check whether a build field actually implies a build must be run
-function isRealBuild(buildField: string): boolean {
+export function isRealBuild(buildField: string): boolean {
   switch (buildField) {
     case 'build.sh':
     case 'build.cmd':


### PR DESCRIPTION
This PR contains the substance of the intended fix for issue #69.   In the now-merged PR #70, we made the rules for `.include` more restrictive and declared the new major version 4.0.0.   Included material, if it isn't in the directory being built, must come from a directory `lib` at the root of the project or subdirectories thereof.

Now we add positive support for the `lib` directory itself.
1.  If the `lib` directory contains a positive build indicator `build.[sh|cmd]` or `package.json`, it is built first before any other directory.   This build may be omitted locally if it is determined that all deployment will be remote.
2. On a remote build, if there is a `lib` directory, it is included in every project slice, where is is built first as in the previous.   Note this may mean that the `lib` directory is built multiple times globally, but never more than once in a given process.

I've created this PR initially with just the code, which has been tested for regressions only.    I'll complete the PR with supporting tests and make sure the code is working as intended before merging.