### PR TITLE
Fix simple-git deprecation warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-deployer",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@nimbella/sdk": "^1.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {

--- a/src/util.ts
+++ b/src/util.ts
@@ -21,7 +21,7 @@ import { Client, Dict, Activation } from 'openwhisk'
 import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
-import simplegit from 'simple-git/promise'
+import simplegit from 'simple-git'
 import * as mime from 'mime-types'
 import * as mimedb from 'mime-db'
 import * as randomstring from 'randomstring'
@@ -982,7 +982,7 @@ export async function getDeployerAnnotation(project: string, githubPath: string)
   }
   const digest = undefined
   try {
-    const git = simplegit().silent(true)
+    const git = simplegit()
     const root = await git.revparse(['--show-toplevel'])
     const repo = await git.raw(['config', '--get', 'remote.origin.url'])
     const user = (await git.raw(['config', '--get', 'user.email'])).trim()


### PR DESCRIPTION
To fix a vulnerability, we have upgraded simple-git to latest version.   This caused deprecation warnings.   This PR tweaks the code in accordance with the known changes and eliminates the warnings.