### PR TITLE
Use set -e in generated remote build scripts

### DIFF
--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -46,6 +46,7 @@ export const BUILDER_NAMESPACE = process.env['TEST_BUILDER_NAMESPACE'] || 'nimbe
 const BUILDER_ACTION_STEM = `/${BUILDER_NAMESPACE}/builder/build_`
 const GET_UPLOAD_URL = `/${BUILDER_NAMESPACE}/buildmgr/getUploadUrl.json`
 const CANNED_REMOTE_BUILD = `#!/bin/bash
+set -e
 /bin/defaultBuild
 `
 


### PR DESCRIPTION
This small change causes failures of the default build to be noticed in runtimes where a default remote build is defined (currently swift and go).