### PR TITLE
Adjust Nimbella CLI and Deployer to changes in remote build actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.0.3",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.27.0",
         "@nimbella/sdk": "^1.3.5",
         "@nimbella/storage": "^0.0.7",
         "@octokit/rest": "^18.7.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "Nimbella Corporation",
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.27.0",
     "@nimbella/sdk": "^1.3.5",
     "@nimbella/storage": "^0.0.7",
     "@octokit/rest": "^18.7.0",


### PR DESCRIPTION
This PR makes two changes to the deployer behavior (which will indirectly affect CLI behavior).
1.  An argument is added on calls to `getUploadUrl`.   This supports improvements to slice naming to make post-mortem debugging of failed remote builds easier.   Older versions of the action will ignore the argument (harmless) while newer ones will use it to improve the naming.
2. More significantly, the `slice-reader` (used when the deployer is running inside a builder action in a runtime container for the purpose of reading the slice from an s3 bucket) now uses the AWS s3 client directly and expects the supporting secrets to be in the environment.   Historically,
    - This code used the Nimbella SDK which _indirectly_ used either the google storage client or the s3 client.  It expected secrets to be in the environment.
    - Starting with deployer 2.0 this code accessed the s3 bucket only via signed URLs and called a separate action to obtain those URLs.  This version was not intended to work on `nimgcp` but works with new deployments being developed at DigitalOcean.
    - With this change, the "double dispatch" is eliminated and the code once again expects s3 secrets in the environment.   However, it no longer uses the google storage client at all, even indirectly, and just uses the AWS client directly.   This is good for efficiency but it requires supporting changes in the builder actions to make the needed secrets available.  This version, too, will only run with the newer deployments.

Because of the interdependency of the changes here on new builder actions, this version of the deployer should not be deployed to runtimes until the new actions are in place.  The new actions will happily run the old code (with double dispatch still in place), but the old actions will not happily run this code.