### PR TITLE
Correct remote builds with script from windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-deployer",
-      "version": "4.0.6",
+      "version": "4.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
When creating a remote build slice, the 'mode' bits of each file are read from the local file system.   So, as long as you mark a shell script 'executable' locally, it will be executable remotely.   Marking `build.sh` executable locally is fine on mac or linux, where the 'executable' bit exists.   But, there is no such bit on windows.   So, when a remote build including `build.sh` is initiated from windows, there is a guaranteed permissions error remotely.

This PR fixes the problem in a somewhat ad hoc way by setting the execute bit on a file in the slice when the initiating OS is windows and the suffix is `.sh`. 