### PR TITLE
Include lib directory in remote build even if if there is no build.sh in it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-deployer",
-      "version": "4.0.7",
+      "version": "4.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -18,7 +18,7 @@ import { DeployStructure, DeployResponse, PackageSpec, OWOptions, WebResource, C
 import { readTopLevel, buildStructureParts, assembleInitialStructure } from './project-reader'
 import {
   isTargetNamespaceValid, wrapError, wipe, saveUsFromOurselves, writeProjectStatus, getTargetNamespace,
-  checkBuildingRequirements, errorStructure, getBestProjectName, inBrowser
+  checkBuildingRequirements, errorStructure, getBestProjectName, inBrowser, isRealBuild
 } from './util'
 import { openBucketClient } from './deploy-to-bucket'
 import { buildAllActions, buildWeb, maybeBuildLib } from './finder-builder'
@@ -159,7 +159,7 @@ export async function buildProject(project: DeployStructure, runtimes: RuntimesC
   debug('Starting buildProject with spec %O', project)
   let webPromise: Promise<WebResource[]|Error>
   project.sharedBuilds = { }
-  if (project.libBuild) {
+  if (project.libBuild && isRealBuild(project.libBuild)) {
     try {
       await maybeBuildLib(project)
     } catch (err) {

--- a/src/project-reader.ts
+++ b/src/project-reader.ts
@@ -154,9 +154,6 @@ export async function buildStructureParts(topLevel: TopLevel, runtimes: Runtimes
   const webPart = await getBuildForLibOrWeb(web, reader, false).then(build => buildWebPart(web, build, reader))
   const actionsPart = await buildActionsPart(packages, displayName, includer, reader, runtimes)
   configPart.libBuild = await getBuildForLibOrWeb(lib, reader, true)
-  if (!isRealBuild(configPart.libBuild)) {
-    configPart.libBuild = undefined
-  }
   return [webPart, actionsPart, configPart]
 }
 


### PR DESCRIPTION
In release v4.0.0 of the deployer we added support for shipping a 'lib' directory in a remote build slice and also support for building that directory if it contained a 'build.sh' script.   Unfortunately, a small logic error ended up conflating these features, so that the lib directory was only included in the slice if it had a build.   That was not the intent and it would certainly be annoying if users had to put vacuous builds in the 'lib' directory to make the feature work.

This change corrects that situation so that the feature introduced in v4.0.0 works correctly.