### PR TITLE
Two changes to remote build logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-deployer",
-      "version": "4.0.8",
+      "version": "4.0.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -119,9 +119,12 @@ async function processRemoteResponse(activationId: string, owClient: openwhisk.C
   let activation: openwhisk.Activation<openwhisk.Dict>
   const tick = () => feedback.progress(`Processing of ${context} is still running remotely ...`)
   try {
-    activation = await waitForActivation(activationId, owClient, tick)
+    activation = await waitForActivation(activationId, owClient, tick, 15*60) // approx 15 minutes limit
   } catch (err) {
     return wrapError(err, context + ' (waiting for remote build response)')
+  }
+  if (!activation) {
+    return wrapError(new Error('Build timed out'), ' (waiting for remote build response)')
   }
   if (!activation.response || !activation.response.success) {
     let err = 'Remote build failed to provide a result'

--- a/src/util.ts
+++ b/src/util.ts
@@ -1245,10 +1245,14 @@ export function delay(millis: number): Promise<void> {
   })
 }
 
-// Await the completion of an action invoke (similar to kui's await)
-export async function waitForActivation(id: string, wsk: Client, waiting: () => void): Promise<Activation<Dict>> {
+// Await the completion of an action invoke.  The poll interval is fixed at 1 second.
+// The 'waiting' argument is called every 10 polls (intended for providing progress feedback).
+// The total wait time should be expressed in #polls.  Because of imprecision in the time
+// management this will generally be longer than #seconds but not by a huge factor.
+// If the wait "times out", undefined is returned.
+export async function waitForActivation(id: string, wsk: Client, waiting: () => void, total: number): Promise<Activation<Dict>> {
   debug(`waiting for activation with id ${id}`)
-  for (let i = 1 ;; i++) {
+  for (let i = 1 ;i <= total; i++) {
     try {
       const activation = await wsk.activations.get(id)
       if (activation.end || activation.response.status) {
@@ -1265,6 +1269,7 @@ export async function waitForActivation(id: string, wsk: Client, waiting: () => 
     }
     await delay(1000)
   }
+  return undefined
 }
 
 // Higher level wrapper around wskRequest for web-secure actions.  Forms the URL


### PR DESCRIPTION
This PR contains two changes in related areas.

1.  The actual value of the `main` property of an action is passed to the `defaultBuild` script (only applies to default remote builds, e.g. for go and Swift).  This change won't be effective until those runtimes are changed to notice the argument.
2.  The `getUploadUrl` action is called without blocking and the activation id is then polled.  This avoids the problems we were seeing with naive blocking invocations which are sometimes disconnected by the controller at one minute.  We are now prepared to wait longer (currently 2 minutes but may be further adjusted).   The early disconnects really should never happen (the action usually completes in a few seconds) but it seems like it does happen when there are few available invokers.