### PR TITLE
Make the 'shared' field of PackageSpec optional

### DIFF
--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -38,7 +38,7 @@ export interface WebResource {
 export interface PackageSpec {
     name: string // The 'default' package is used to hold actions with no package.  Only the 'actions' member is processed then.
     actions?: ActionSpec[]
-    shared: boolean // Indicates that the package is intended to be shared (public)
+    shared?: boolean // Indicates that the package is intended to be shared (public)
     annotations?: Dict // package annotations
     parameters?: Dict // Bound parameters for all actions in the package, passed in the usual way
     environment?: Dict // Bound parameters for all actions in the package, destined to go in the environment of each action


### PR DESCRIPTION
At one time, boolean fields in many structures in `deploy-struct.ts` were "required" on the theory that they could just be set to false.   At some point we moved to making all fields that weren't strictly required truly optional (could be omitted).  The `shared` property of `PackageSpec` got left out of that change.  This PR rectifies that.