### PR TITLE
Include activation in remote build errors

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -136,7 +136,9 @@ async function processRemoteResponse(activationId: string, owClient: openwhisk.C
         err = parts[parts.length - 1]
       }
     }
-    return wrapError(new Error(err), context + ' (running remote build)')
+    const thrown = new Error(err) as any
+    thrown.activation = JSON.stringify(activation, null, 2) // ensure deep enough nesting
+    return wrapError(thrown, context + ' (running remote build)')
   }
   const result = activation.response.result as Record<string, any>
   debug('Remote result was %O', result)

--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -903,7 +903,9 @@ async function getUploadUrl(owClient: openwhisk.Client, params: { action: string
         err = parts[parts.length - 1]
       }
     }
-    throw new Error(err)
+    const thrown = new Error(err) as any
+    thrown.activation = JSON.stringify(activation, null, 2) // ensure deep enough nesting
+    throw thrown
   }
   const result = activation.response.result as Record<string, any>
   return { url: result.url, sliceName: result.sliceName }


### PR DESCRIPTION
This change causes the entire activation to be included in any error that is thrown when an activation is returned by a remote build action (including `getUploadUrl`) but is invalid or indicates an error.

Normally, this extra field is ignored but when `--verbose` is set on a `nim` invocation (or `DEBUG=nim:error` is set on a `doctl sbx` invocation), it will be displayed.  To ensure that the entire activation is displayed and not "depth-truncated" it is JSON serialized before being placed in the error object.
