### PR TITLE
Better support for multi-line string values in substituting values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.0.12",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-deployer",
-      "version": "4.0.12",
+      "version": "4.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.0.12",
+  "version": "4.1.0",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {

--- a/src/util.ts
+++ b/src/util.ts
@@ -806,6 +806,8 @@ export function substituteFromEnvAndFiles(input: string, envPath: string, projec
     if (!subst) {
       badVars.push(envar)
       subst = `<${envar}>`
+    } else {
+      subst = escapeNewlines(subst)
     }
     debug('substitution is: %s', subst)
     result = result + before + subst
@@ -820,6 +822,12 @@ export function substituteFromEnvAndFiles(input: string, envPath: string, projec
     return { content: result, badVars } 
   }
   return { content: result, badVars: undefined }
+}
+
+// Perform escaping of newlines.
+function escapeNewlines(original: string): string {
+  const parts = original.split('\n')
+  return parts.join('\\n')
 }
 
 // Scan forward for the next symbol introducer

--- a/src/util.ts
+++ b/src/util.ts
@@ -789,7 +789,8 @@ export function substituteFromEnvAndFiles(input: string, envPath: string, projec
       throw new Error('Runaway variable name or path directive in project.yml')
     }
     let subst: string
-    const envar = after.substr(0, endVar).trim()
+    let doStringEscapes = true
+    let envar = after.substr(0, endVar).trim()
     debug('substituting for envar: %s', envar)
     if (nextSym.terminator === ')' || /\s/.test(envar)) {
       warn = warn || nextSym.terminator !== ')'
@@ -798,15 +799,19 @@ export function substituteFromEnvAndFiles(input: string, envPath: string, projec
       if (nextSym.terminator === ')') {
         throw new Error('Invalid substitution: $(' + envar + ')')
       }
-      const fileSubst = path.join(projectPath, envar.slice(1))
+      const fileSubst = path.join(projectPath, envar.slice(1).trim())
       subst = getSubstituteFromFile(fileSubst)
     } else {
+      if (envar.startsWith('|')) {
+        envar = envar.slice(1).trim()
+        doStringEscapes = false
+      }
       subst = process.env[envar] || props[envar]
     }
     if (!subst) {
       badVars.push(envar)
       subst = `<${envar}>`
-    } else {
+    } else if (doStringEscapes) {
       subst = escapeNewlines(subst)
     }
     debug('substitution is: %s', subst)


### PR DESCRIPTION
There are use cases in which you want to provide multi-line secrets to become part of a parameter or environment value bound to a package or action.   For example, certificate files.   It has been difficult to do this.

1.  Both file substitution  and the `$()` syntax are non-starters because they must have dictionary values.  They can't be used to set a single string value in larger dictionary.
2.  To use the ${} syntax correctly when there are internal newlines, you have to do some extra work.   One option is to enlist the help of the YAML parser by using an explicit `|-`  and placing the substituting value into the block thus created.   This requires painstaking attention to the indentation.
3.  Another option is to escape the newlines in the string with `\\n` so that, by the time the YAML parser sees the value there are still `\n` escapes.

While (3) is probably the most reliable option it is a bad experience to have to transform a file of many lines into a linear value this way.

This change causes the deployer to notice when a substituting value has newlines in it.  It then escapes the value for you using option (3).

While this is undoubtedly what you _almost_ always want, there could be valid use cases where you are deliberately using a substitution value to insert multiple lines of YAML into the configuration.    You can now get this behavior by adding a pipe symbol within the braces.   That is, if `FOO` is a symbol that might have a multiline value, then `${FOO}` will insert the value with the newlines escaped and `${|FOO}` will insert the value as is with newlines.