### PR TITLE
Switch to newer dotenv version (multiline support)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-deployer",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "atob": "^2.1.2",
         "axios": "^0.21.4",
         "debug": "^4.1.1",
-        "dotenv": "7.0.0",
+        "dotenv": "^16.0.1",
         "ignore": "5.0.6",
         "js-yaml": "^3.13.1",
         "memory-streams": "^0.1.3",
@@ -3582,11 +3582,11 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
-      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
     },
     "node_modules/duplexify": {
@@ -10261,9 +10261,9 @@
       }
     },
     "dotenv": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
-      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g=="
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
     },
     "duplexify": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "atob": "^2.1.2",
     "axios": "^0.21.4",
     "debug": "^4.1.1",
-    "dotenv": "7.0.0",
+    "dotenv": "^16.0.1",
     "ignore": "5.0.6",
     "js-yaml": "^3.13.1",
     "memory-streams": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
The deployer had had the `dotenv` dependency locked at 7.0.0 which doesn't support the now-documented multi-line value syntax on the `dotenv` web-site.   This change merely ups the dependency to the latest `dotenv`.