### PR TITLE
Use .deployed, not .nimbella, for status directory

### DIFF
--- a/src/project-reader.ts
+++ b/src/project-reader.ts
@@ -108,6 +108,7 @@ export async function readTopLevel(filePath: string, env: string, buildEnv: stri
           lib = libDir
           break
         case '.nimbella':
+        case '.deployed':
           break
         default:
           strays.push(item.name)

--- a/src/util.ts
+++ b/src/util.ts
@@ -37,6 +37,7 @@ const debug = makeDebug('nim:deployer:util')
 // List of files/paths to be ignored, add https://github.com/micromatch/anymatch compatible definitions
 export const SYSTEM_EXCLUDE_PATTERNS = ['.gitignore', '.DS_Store', '**/.git/**',
   (s: string): boolean => s.includes('.nimbella'),
+  (s: string): boolean => s.includes('.deployed'),
   (s: string): boolean => s.includes('_tmp_'),
   (s: string): boolean => s.includes('.#'),
   (s: string): boolean => s.endsWith('~'),
@@ -1167,7 +1168,7 @@ export function digestAction(action: ActionSpec, code: string): string {
 
 // Get the status reporting directory, making it if it doesn't exist
 function getStatusDir(project: string): { statusDir: string, created: boolean } {
-  const statusDir = path.join(project, '.nimbella')
+  const statusDir = path.join(project, '.deployed')
   let created = false
   if (!fs.existsSync(statusDir)) {
     fs.mkdirSync(statusDir)
@@ -1239,7 +1240,7 @@ function mergeVersions(oldEntry: VersionEntry, newEntry: VersionEntry, replace: 
 
 // Load the version information of a project for a namespace and apihost.  Return an appropriately empty structure if not found.
 export function loadVersions(projectPath: string, namespace: string, apihost: string): VersionEntry {
-  const versionFile = path.join(projectPath, '.nimbella', 'versions.json')
+  const versionFile = path.join(projectPath, '.deployed', 'versions.json')
   if (fs.existsSync(versionFile)) {
     const allEntries = JSON.parse(String(fs.readFileSync(versionFile)))
     for (const entry of allEntries) {


### PR DESCRIPTION
This change renames the `.nimbella` directory that is stored at the root of a deployed project and typically contains deployment information.   The new name is `.deployed`.    For backward compatibility, a `.nimbella` directory is ignored during project reading just as before and the new `.deployed` directory will be written alongside it.  Backward compatibility is not perfect, however, in the sense that once you switch to the new deployer, the `.nimbella` directory will no longer be used for tracking deployment status for things like file watching and incremental deploy.   Once the new `.deployed` directory is populated, behavior will be as before.