### PR TITLE
Rename actions to functions in visible project.yml

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export {
 } from './credentials'
 export { cleanBucket, restore404Page, makeStorageClient } from './deploy-to-bucket'
 export { wskRequest, inBrowser, delay, writeSliceResult, getBestProjectName, isTextType, renamePackage, setInBrowserFlag, getExclusionList, isExcluded, 
-  SYSTEM_EXCLUDE_PATTERNS, getRuntimeForAction, emptyStructure, invokeWebSecure } from './util'
+  SYSTEM_EXCLUDE_PATTERNS, getRuntimeForAction, emptyStructure, invokeWebSecure, renameActionsToFunctions } from './util'
 export * from './runtimes'
 export { GithubDef, isGithubRef, parseGithubRef, fetchProject } from './github'
 export { deleteSlice } from './slice-reader'

--- a/tests/unit/util.test.ts
+++ b/tests/unit/util.test.ts
@@ -36,13 +36,7 @@ describe('test validation of loading project configuration', () => {
       }
     }
     const result = await loadProjectConfig('project.yml', '', '', '', (reader as unknown) as ProjectReader, null, {} as RuntimesConfig)
-    let expectedText
-    if (process.version.startsWith('v16')) {
-      expectedText = `Cannot read properties of undefined (reading 'slice')`
-    } else {
-      expectedText = `Cannot read property 'slice' of undefined`
-    }
-    expect(result.error.message).toBe(`Invalid project configuration file (project.yml): ${expectedText}`)
+    expect(result.error.message).toBe('Invalid project configuration file (project.yml): configuration is empty or unparseable')
   })
   test('should parse minimal YAML file', async () => {
     const reader = {


### PR DESCRIPTION
This PR changes a visible member `.packages.functions` in a  `project.yml` file to be `.packages.actions` internally and vice versa when a configuration is turned back into a visible `project.yml`.

The idea is to move away from the openwhisk terminology ('actions') toward a more industry-standard terminology ('functions') in the externals, while avoiding a major disruption internally.

This is not the end of the story.  The term 'actions' appears in other places in the externals and those may be addressed separately.   The scope here is limited to `project.yml`.