### PR TITLE
Fix combination of --remote-build, --verbose-build, and actual build failure.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-deployer",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
The intent of `--verbose-build` is to cause a build transcript on output regardless of whether the build "failed" or not (according to its exit code).    If the build actually fails,  though, the build transcript should be displayed in any case, and so the flag should have no effect.

This is what happens with local builds.

Up to this change, remote builds were not behaving similarly.   If `--verbose-build` was not specified, the transcript was presented only if the build failed (as designed).   If `--verbose-build` was specified and the build succeeded, the transcript was output (as designed).   But if `--verbose-build` was specified _and_ the build failed, the transcript was omitted, contrary to the intent of the flag.

That error is fixed in this change.