### PR TITLE
Support larger slice uploads

### DIFF
--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -32,6 +32,7 @@ import * as memoryStreams from 'memory-streams'
 import openwhisk = require('openwhisk')
 import { RuntimesConfig, canonicalRuntime } from './runtimes'
 import { onlyDeployPackage } from './deploy'
+import { MAX_SLICE_UPLOAD_SIZE } from './slice-reader'
 
 const debug = makeDebug('nim:deployer:finder-builder')
 const zipDebug = makeDebug('nim:deployer:zip')
@@ -777,7 +778,7 @@ interface ProjectSliceZip {
     outputPromise: Promise<any>
 }
 function makeProjectSliceZip(context: string): ProjectSliceZip {
-  const output: Writable = new memoryStreams.WritableStream({ highWaterMark: 8 * 1024 * 1024 })
+  const output: Writable = new memoryStreams.WritableStream({ highWaterMark: MAX_SLICE_UPLOAD_SIZE })
   const zip = archiver('zip')
   const outputPromise = new Promise(function(resolve, reject) {
     zip.on('error', err => {
@@ -923,7 +924,12 @@ async function invokeRemoteBuilder(zipped: Buffer, credentials: Credentials, owC
     throw new Error(msg)
   }
   debug('remote build url is %s', url)
-  const result = await axios.put(url, zipped)
+  const axiosConfig = {
+    // Override capacity limiting defaults 
+    maxBodyLength: MAX_SLICE_UPLOAD_SIZE,
+    maxContentLength: MAX_SLICE_UPLOAD_SIZE
+  }
+  const result = await axios.put(url, zipped, axiosConfig)
   if (result.status !== 200) {
     throw new Error(`Bad response [$result.status}] when uploading '${sliceName}' for remote build`)
   }

--- a/src/finder-builder.ts
+++ b/src/finder-builder.ts
@@ -688,11 +688,7 @@ async function appendAndCheck(zip: archiver.Archiver, file: string, actionPath: 
   }
   debug(`mode for ${file} is ${mode}`)
   zip.append(contents, { name: file, mode })
-  const size = zip.pointer()
-  if (size > 512 * 1024) {
-    throw new Error(`Remote build upload for '${actionPath}' exceeds 512K.  Make sure the directory is free of derived artifacts`)
-  }
-  zipDebug("zipped '%s' for remote build slice, emitted %d", file, size)
+  zipDebug("zipped '%s' for remote build slice", file)
 }
 
 // Initiate request to builder for building web content
@@ -781,7 +777,7 @@ interface ProjectSliceZip {
     outputPromise: Promise<any>
 }
 function makeProjectSliceZip(context: string): ProjectSliceZip {
-  const output: Writable = new memoryStreams.WritableStream({ highWaterMark: 1024 * 1024 })
+  const output: Writable = new memoryStreams.WritableStream({ highWaterMark: 8 * 1024 * 1024 })
   const zip = archiver('zip')
   const outputPromise = new Promise(function(resolve, reject) {
     zip.on('error', err => {

--- a/src/slice-reader.ts
+++ b/src/slice-reader.ts
@@ -27,6 +27,9 @@ const bucket = process.env.BUILDER_BUCKET_NAME
 const endpoint = process.env.S3_ENDPOINT
 // Environment must also contain AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
 
+// MAX_SLICE_UPLOAD_SIZE governs the maximum supported zipped size for a project slice 
+export const MAX_SLICE_UPLOAD_SIZE = parseInt(process.env.MAX_SLICE_UPLOAD_SIZE) || 64 * 1024 * 1024
+
 let s3Client: S3Client
 
 // Supports the fetching and deletion of project slices from build bucket.
@@ -75,7 +78,7 @@ export async function fetchSlice(sliceName: string): Promise<string> {
   const cmd = new GetObjectCommand({ Bucket: bucket, Key: sliceName })
   const result = await s3.send(cmd)
   const content = result.Body as Readable // Body has type ReadableStream<any>|Readable|Blob.  Readable seems to work in practice
-  const destination = new WritableStream({ highWaterMark: 8 * 1024 * 1024 })
+  const destination = new WritableStream({ highWaterMark: MAX_SLICE_UPLOAD_SIZE })
   await pipe(content, destination)
   const data = (destination as WritableStream).toBuffer()
   const zip = new Zip(data)

--- a/src/slice-reader.ts
+++ b/src/slice-reader.ts
@@ -75,7 +75,7 @@ export async function fetchSlice(sliceName: string): Promise<string> {
   const cmd = new GetObjectCommand({ Bucket: bucket, Key: sliceName })
   const result = await s3.send(cmd)
   const content = result.Body as Readable // Body has type ReadableStream<any>|Readable|Blob.  Readable seems to work in practice
-  const destination = new WritableStream({ highWaterMark: 1024 * 1024 })
+  const destination = new WritableStream({ highWaterMark: 8 * 1024 * 1024 })
   await pipe(content, destination)
   const data = (destination as WritableStream).toBuffer()
   const zip = new Zip(data)


### PR DESCRIPTION
For a not-very-good reason, slice uploads for remote builds have been limited to 0.5mb.   This change allows slice uploads to be as large as 64mb. 