### PR TITLE
Initial support for triggers in the deployer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "archiver": "^5.3.0",
         "atob": "^2.1.2",
         "axios": "^0.21.4",
+        "cron-validator": "^1.3.1",
         "debug": "^4.1.1",
         "dotenv": "^16.0.1",
         "ignore": "5.0.6",
@@ -3400,6 +3401,11 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/cron-validator": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cron-validator/-/cron-validator-1.3.1.tgz",
+      "integrity": "sha512-C1HsxuPCY/5opR55G5/WNzyEGDWFVG+6GLrA+fW/sCTcP6A6NTjUP2AK7B8n2PyFs90kDG2qzwm8LMheADku6A=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -10119,6 +10125,11 @@
         "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
       }
+    },
+    "cron-validator": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cron-validator/-/cron-validator-1.3.1.tgz",
+      "integrity": "sha512-C1HsxuPCY/5opR55G5/WNzyEGDWFVG+6GLrA+fW/sCTcP6A6NTjUP2AK7B8n2PyFs90kDG2qzwm8LMheADku6A=="
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "archiver": "^5.3.0",
     "atob": "^2.1.2",
     "axios": "^0.21.4",
+    "cron-validator": "^1.3.1",
     "debug": "^4.1.1",
     "dotenv": "^16.0.1",
     "ignore": "5.0.6",

--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -71,11 +71,31 @@ export interface ActionSpec {
     clean?: boolean // Indicates that an old copy of the action should be removed before deployment
     remoteBuild?: boolean // States that the build (if any) must be done remotely
     localBuild?: boolean // States that the build (if any) must be done locally (precludes a github deploy in the cloud)
+    triggers?: TriggerSpec[] // Triggers for the function if any
     // Build information (not specifiable in the config)
     build?: string
     wrapping?: string
     buildResult?: string // The activation id of the remote build
     buildError?: Error // Error reported from the build step
+}
+
+// Information about one trigger.  An action can have many triggers.  However, different actions may not
+// share the same trigger.
+export interface TriggerSpec {
+    name: string // The name of the trigger.  Must be unique within the namespace.
+    sourceType: string // Currently, the one supported value "scheduler" is required.
+    sourceDetails: any // Currently, must conform to SchedulerSourceDetails
+    overwrite?: boolean // Assumed false if omitted
+    enabled?: boolean // Assumed true if omitted 
+}
+
+// The type used for the sourceDetails of a trigger whose sourceType is "scheduler"
+export interface SchedulerSourceDetails {
+    cron?: string      // must be a cron expression
+    interval?: number  // in minutes (not yet implemented) 
+    once?: string      // an ISO-format date (not yet implemented)
+    // (cron, interval and once are mutually exclusive)
+    withBody?:  object // optional body to use when posting the function
 }
 
 // Information of various kinds typically specified on the command line

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022 - present DigitalOcean, LLC
+ *
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// Includes support for installing triggers and removing in the scheduling server, when such triggers 
+// are attached to an action.  Currently, only sourceType=scheduler is supported for triggers.  Others will
+// be rejected.  Eventually, this can be replaced by a dispatching discipline of some sort that looks at the
+// sourceType and calls specialized code for that source type.
+
+// TEMPORARY: this code is invoking actions in /nimbella/triggers/[create|delete] rather than APIs on
+// <digitalOceanAPI>/V2/functions/namespaces/<namespace>/triggers.  As such, it uses an OpenWhisk client
+// to communicate instead of direct use of https with a DigitalOcean access token for authorization.
+// This should change over as soon as the APIs are available on the edge service.
+// This should be the only file that has to change.
+
+import openwhisk from 'openwhisk'
+import { TriggerSpec, SchedulerSourceDetails } from './deploy-struct'
+
+export async function deployTriggers(triggers: TriggerSpec[], functionName: string, 
+    wsk: openwhisk.Client): Promise<object[]> {
+  const promises: Promise<object>[] = []
+  for (const trigger of triggers) {
+    promises.push(deployTrigger(trigger, functionName, wsk))   
+  }
+  return Promise.all(promises)
+}
+
+export async function undeployTriggers(triggers: string[], wsk: openwhisk.Client): Promise<void> {
+  for (const trigger of triggers) {
+    await undeployTrigger(trigger, wsk)
+  }
+}
+
+// Temporary code to deploy the trigger using the prototype API
+// Note that basic structural validation of each trigger has been done previously
+// so paranoid checking is omitted.
+async function deployTrigger(trigger: TriggerSpec, functionName: string, wsk: openwhisk.Client): Promise<object> {
+  const details = trigger.sourceDetails as SchedulerSourceDetails
+  const { cron, withBody } = details
+  const { sourceType, overwrite, enabled } = trigger
+  const params = {
+    triggerName: trigger.name,
+    function: functionName,
+    sourceType,
+    cron,
+    withBody,
+    overwrite,
+    enabled
+  }
+  return await wsk.actions.invoke({
+    name: '/nimbella/triggers/create',
+    params,
+    blocking: true,
+    result: true
+  })
+}
+
+// Temporary code to undeploy a trigger using the prototype API
+async function undeployTrigger(trigger: string, wsk: openwhisk.Client) {
+  const params = {
+    triggerName: trigger
+  }
+  console.log('undeploying', trigger)
+  return await wsk.actions.invoke({
+    name: '/nimbella/triggers/delete',
+    params,
+    blocking: true,
+    result: true
+  })
+}
+
+// Temporary code to get all the triggers for a namespace using the prototype API
+export async function listTriggersForNamespace(wsk: openwhisk.Client): Promise<string[]> {
+  const triggers = await wsk.actions.invoke({
+    name: '/nimbella/triggers/list',
+    blocking: true,
+    result: true
+  })
+  return triggers.items.map(trigger => trigger.triggerName)
+}

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -16,11 +16,9 @@
 // be rejected.  Eventually, this can be replaced by a dispatching discipline of some sort that looks at the
 // sourceType and calls specialized code for that source type.
 
-// TEMPORARY: this code is invoking actions in /nimbella/triggers/[create|delete] rather than APIs on
-// <digitalOceanAPI>/V2/functions/namespaces/<namespace>/triggers.  As such, it uses an OpenWhisk client
-// to communicate instead of direct use of https with a DigitalOcean access token for authorization.
-// This should change over as soon as the APIs are available on the edge service.
-// This should be the only file that has to change.
+// TEMPORARY: this code is invoking actions in /nimbella/triggers/[create|delete|list|get] rather than
+// APIs more closely associated with the scheduling service.   This is likely to change if this
+// direction is adopted longer term. This should be the only file that has to change.
 
 import openwhisk from 'openwhisk'
 import { TriggerSpec, SchedulerSourceDetails } from './deploy-struct'


### PR DESCRIPTION
This change allows "triggers" to be associated with functions ("actions") at the time of deployment.   These are not OpenWhisk triggers but rather a (currently experimental) form of trigger managed elsewhere.   Unlike OpenWhisk triggers, these do not require OpenWhisk rules to link them to functions.  Rather, each trigger is bound to exactly one function (a function may have more than one trigger, however).

CRUD operations on these triggers are currently managed via system actions.   The linkage between functions and triggers is a loose one, recorded in annotations on the function.  The deployer will delete associated triggers when it deletes a function.  But, note that deletion of functions is often not done by the deployer but using the more primitive function delete operation driven directly from `nim` or `doctl sls undeploy`.    If this direction is adopted, those CLIs will need to change so as to go through the deployer when deleting a function.