### PR TITLE
Always overwrite when creating triggers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-deployer",
-      "version": "4.3.1",
+      "version": "4.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {

--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -85,7 +85,6 @@ export interface TriggerSpec {
     name: string // The name of the trigger.  Must be unique within the namespace.
     sourceType: string // Currently, the one supported value "scheduler" is required.
     sourceDetails: any // Currently, must conform to SchedulerSourceDetails
-    overwrite?: boolean // Assumed false if omitted
     enabled?: boolean // Assumed true if omitted 
 }
 

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -44,14 +44,14 @@ export async function undeployTriggers(triggers: string[], wsk: openwhisk.Client
 async function deployTrigger(trigger: TriggerSpec, functionName: string, wsk: openwhisk.Client): Promise<object> {
   const details = trigger.sourceDetails as SchedulerSourceDetails
   const { cron, withBody } = details
-  const { sourceType, overwrite, enabled } = trigger
+  const { sourceType, enabled } = trigger
   const params = {
     triggerName: trigger.name,
     function: functionName,
     sourceType,
     cron,
     withBody,
-    overwrite,
+    overwrite: true,
     enabled
   }
   return await wsk.actions.invoke({


### PR DESCRIPTION
For consistency with how the deployer handles other resources, triggers should always be created with `overwrite: true`.

This change removes the `overwrite` option from the triggers clause in `project.yml` and instead always calls the trigger creation API with the option forced to `true`.