### PR TITLE
Remove improper console.log statement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-deployer",
-      "version": "4.3.2",
+      "version": "4.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -67,7 +67,6 @@ async function undeployTrigger(trigger: string, wsk: openwhisk.Client) {
   const params = {
     triggerName: trigger
   }
-  console.log('undeploying', trigger)
   return await wsk.actions.invoke({
     name: '/nimbella/triggers/delete',
     params,


### PR DESCRIPTION
The 4.2.2 release left in place an inappropriately chatty message in the deployment of triggers that had been added for debugging.