### PR TITLE
Tighter trigger linkage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-deployer",
-      "version": "4.3.3",
+      "version": "4.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -517,13 +517,6 @@ async function deployActionFromCodeOrSequence(action: ActionSpec, spec: DeploySt
   const name = getActionName(action)
   const { versions, flags, deployerAnnotation, owClient: wsk } = spec
   const deployerAnnot = Object.assign({}, deployerAnnotation)
-  const triggers = action.triggers?.map(trigger => {
-    return {
-      name: trigger.name,
-      sourceType: trigger.sourceType,
-      sourceDetails: trigger.sourceDetails
-    }
-  })
 
   debug('deploying %s using %s', name, !sequence ? 'code' : 'sequence info')
   if (code && !action.runtime) {
@@ -554,9 +547,6 @@ async function deployActionFromCodeOrSequence(action: ActionSpec, spec: DeploySt
   const annotations = Object.assign({}, action.annotations) || {}
   annotations.deployer = deployerAnnot
   annotations.final = true
-  if (triggers && triggers.length > 0) {
-    annotations.triggers = triggers
-  }
   
   if (action.web === true) {
     annotations['web-export'] = true
@@ -595,7 +585,6 @@ async function deployActionFromCodeOrSequence(action: ActionSpec, spec: DeploySt
     const response = await wsk.actions.update(deployParams)
     if (action.triggers) {
       await deployTriggers(action.triggers, name, wsk)
-      // TODO what, if anything, do we do with normal output?
     }
     const map = {}
     if (digest) {

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -11,12 +11,12 @@
  * governing permissions and limitations under the License.
  */
 
-// Includes support for installing triggers and removing in the scheduling server, when such triggers 
-// are attached to an action.  Currently, only sourceType=scheduler is supported for triggers.  Others will
-// be rejected.  Eventually, this can be replaced by a dispatching discipline of some sort that looks at the
-// sourceType and calls specialized code for that source type.
+// Includes support for listing, installing, and removing triggers in the scheduling server, when such
+// triggers are attached to an action.  Currently, only sourceType=scheduler is supported for triggers.
+// Others will be rejected.  Eventually, this can be replaced by a dispatching discipline of some sort
+// that looks at the sourceType and calls specialized code for that source type.
 
-// TEMPORARY: this code is invoking actions in /nimbella/triggers/[create|delete|list|get] rather than
+// TEMPORARY: this code is invoking actions in /nimbella/triggers/[create|delete|list] rather than
 // APIs more closely associated with the scheduling service.   This is likely to change if this
 // direction is adopted longer term. This should be the only file that has to change.
 
@@ -75,12 +75,14 @@ async function undeployTrigger(trigger: string, wsk: openwhisk.Client) {
   })
 }
 
-// Temporary code to get all the triggers for a namespace using the prototype API
-export async function listTriggersForNamespace(wsk: openwhisk.Client): Promise<string[]> {
+// Temporary code to get all the triggers for a namespace, or all the triggers for a function in the
+// namespace, using the prototype API.
+export async function listTriggersForNamespace(wsk: openwhisk.Client, fcn?: string): Promise<string[]> {
   const triggers = await wsk.actions.invoke({
     name: '/nimbella/triggers/list',
+    params: fcn ? { function: fcn } : undefined,
     blocking: true,
     result: true
   })
-  return triggers.items.map(trigger => trigger.triggerName)
+  return triggers.items.map((trigger: any) => trigger.triggerName)
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1238,17 +1238,14 @@ async function wipeAll(handle: any, kind: string) {
   }
 }
 
-// Delete an action while also deleting any triggers that are affixed to it via its triggers annotation
+// Delete an action while also deleting any DigitalOcean triggers that are targetting it
 export async function deleteAction(actionName: string, owClient: Client): Promise<Action> {
-  // First delete the action itself.  If this fails it will throw
-  // Retain the return value, which is a copy of the action's metadata
+  // First delete the action itself.  If this fails it will throw.
+  // Save the action contents so they can be returned as a result.
   const action = await owClient.actions.delete({ name: actionName})
   // Delete associated triggers (if any)
-  const triggers = action.annotations?.find(annot => annot.key === 'triggers')?.value
-  if (triggers && Array.isArray(triggers)) {
-    const triggerNames = triggers.map((trigger: { name: string }) => trigger.name)
-    await undeployTriggers(triggerNames, owClient)
-  }
+  const triggers = await listTriggersForNamespace(owClient, actionName)
+  await undeployTriggers(triggers, owClient)
   return action
 }
 


### PR DESCRIPTION
The function associated with a trigger can be determined by examining the trigger. The triggers that belong to a function could not be determined by examining the function alone, so, when adding trigger support to the deployer, I first relied on recording this information in function annotations.

That decision turned out to be awkward and fragile if the goal is to maintain an invariant that a trigger should not be allowed to exist pointing to a function that does not exist.

With this change, the deployer interrogates the triggers API to find the triggers that belong to a function whenever a function is being deleted.    All such triggers will be deleted when the function is deleted.

The `triggers` annotation is retired with this change and won't be used going forward.   Arguably, the annotation could function as a "helpful hint" (not canonical) but I think it's just too likely to be stale and misleading.