### PR TITLE
Map the .ts suffix to the nodejs runtime

### DIFF
--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -22,18 +22,20 @@ export type RuntimesConfig = Record<RuntimeLabel, Runtime[]>
 
 // List of file extensions for runtimes. This hardcoded list used to be present
 // in the extensions field of the runtimes.json document.
+// The commented-out lines are not currently supported by DigitalOcean;
+// some may be supported in the future.
 const FileExtensionRuntimes: Record<RuntimeKind, RuntimeFileExtension[]> = {
   'go': ['go'],
-  'java': ['java', 'jar'],
-  'nodejs': ['js'],
-  'typescript': ['ts'],
+//  'java': ['java', 'jar'],
+  'nodejs': ['js', 'ts'], // nodejs works for both javascript and typescript
+//  'typescript': ['ts'],
   'php': ['php'],
   'python': ['py'],
-  'ruby': ['rb'],
-  'rust': ['rs'],
-  'swift': ['swift'],
-  'deno': ['ts', 'js'],
-  'dotnet': ['cs', 'vb']
+//  'ruby': ['rb'],
+//  'rust': ['rs'],
+//  'swift': ['swift'],
+//  'deno': ['ts', 'js'],
+//  'dotnet': ['cs', 'vb']
 }
 
 // File extensions which imply binary data

--- a/tests/unit/runtimes.test.ts
+++ b/tests/unit/runtimes.test.ts
@@ -176,16 +176,16 @@ describe('test finding default runtimes', () => {
 describe('test determing runtime for an extension', () => {
   test('should return runtimes for hardcoded extensions', () => {
     const known_runtimes = {
-      'rs': 'rust:default',
+//      'rs': 'rust:default',
       'js': 'nodejs:default',
       'py': 'python:default',
-      'ts': 'typescript:default',
-      'java': 'java:default',
-      'jar': 'java:default',
+      'ts': 'nodejs:default',
+//      'java': 'java:default',
+//      'jar': 'java:default',
       'go': 'go:default',
-      'swift': 'swift:default',
+//      'swift': 'swift:default',
       'php': 'php:default',
-      'rb': 'ruby:default',
+//      'rb': 'ruby:default',
     }
 
     for (let [extension, runtime] of Object.entries(known_runtimes)) {
@@ -222,21 +222,21 @@ describe('test determining extension from runtime', () => {
   test('should return extensions for known non-binary runtimes (version & default)', () => {
     const known_runtimes = {
       'go': ['go'],
-      'java': ['java', 'jar'],
-      'nodejs': ['js'],
-      'typescript': ['ts'],
+//      'java': ['java', 'jar'],
+      'nodejs': ['js', 'ts'],
       'php': ['php'],
       'python': ['py'],
-      'ruby': ['rb'],
-      'rust': ['rs'],
-      'swift': ['swift'],
-      'deno': ['ts', 'js'],
-      'dotnet': ['cs', 'vb']
+//      'ruby': ['rb'],
+//      'rust': ['rs'],
+//      'swift': ['swift'],
+//      'deno': ['ts', 'js'],
+//      'dotnet': ['cs', 'vb']
     }
     for (let [runtime, extension] of Object.entries(known_runtimes)) {
       expect(fileExtensionForRuntime(runtime, false)).toEqual(extension[0])
     }
   })
+  /*
   test('should return extensions for known binary runtimes (version & default)', () => {
     const known_runtimes = {
       'java': ['java', 'jar']
@@ -245,6 +245,7 @@ describe('test determining extension from runtime', () => {
       expect(fileExtensionForRuntime(runtime, true)).toEqual(extension[1])
     }
   })
+  */
 
   test('should return undefined for unknown runtimes', () => {
     expect(() => fileExtensionForRuntime('unknown:10', false)).toThrow(`Invalid runtime unknown:10 encountered`)


### PR DESCRIPTION
This change accepts the suffix `.ts` (TypeScript source file) as implying the `nodejs` runtime, in addition to suffix `.js`.   The  typescript runtime is not likely to be resurrected.

The change also eliminates mappings for runtimes that are not currently supported in DigitalOcean.   Some of these runtimes may be resurrected in the future but, meanwhile, it is less confusing if they are treated as invalid consistently, rather than being accepted in one place only to be rejected in another.