### PR TITLE
Switch triggers support to the candidate "official" API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.3.6",
+  "version": "4.3.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-deployer",
-      "version": "4.3.6",
+      "version": "4.3.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.3.6",
+  "version": "4.3.7",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {

--- a/src/deploy-struct.ts
+++ b/src/deploy-struct.ts
@@ -211,7 +211,7 @@ export interface VersionMap {
     [key: string]: VersionInfo
 }
 
-export type DeployKind = 'web' | 'action'
+export type DeployKind = 'web' | 'action' | 'trigger'
 
 export interface DeploySuccess {
     name: string

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -584,7 +584,7 @@ async function deployActionFromCodeOrSequence(action: ActionSpec, spec: DeploySt
   try {
     const response = await wsk.actions.update(deployParams)
     if (action.triggers) {
-      await deployTriggers(action.triggers, name, wsk)
+      await deployTriggers(action.triggers, name, wsk, spec.credentials.namespace)
     }
     const map = {}
     if (digest) {

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -13,7 +13,7 @@
 
 import {
   DeployStructure, DeployResponse, ActionSpec, PackageSpec, WebResource, BucketSpec, VersionEntry,
-  ProjectReader, OWOptions, KeyVal, Feedback
+  ProjectReader, OWOptions, KeyVal, Feedback, DeploySuccess
 } from './deploy-struct'
 import { StorageClient } from '@nimbella/storage'
 import {
@@ -583,19 +583,33 @@ async function deployActionFromCodeOrSequence(action: ActionSpec, spec: DeploySt
   const deployParams = { name, action: actionBody }
   try {
     const response = await wsk.actions.update(deployParams)
+    
+    let triggerResults: (DeploySuccess|Error)[] = []
     if (action.triggers) {
-      await deployTriggers(action.triggers, name, wsk, spec.credentials.namespace)
+      triggerResults = await deployTriggers(action.triggers, name, wsk, spec.credentials.namespace)
     }
     const map = {}
     if (digest) {
       map[name] = { version: response.version, digest }
     }
     const namespace = response.namespace.split('/')[0]
-    return Promise.resolve(wrapSuccess(name, 'action', false, action.wrapping, map, namespace))
+    const success = wrapSuccess(name, 'action', false, action.wrapping, map, namespace)
+    for (let i = 0; i < triggerResults.length; i++) {
+      if (triggerResults[i] instanceof Error) {
+        const err = triggerResults[i] as any
+        err.context = `while deploying trigger '${action.triggers[i].name}'`
+        success.failures.push(triggerResults[i] as Error)
+      } else {
+        success.successes.push(triggerResults[i] as DeploySuccess)
+      }
+    }
+    return Promise.resolve(success)
   } catch(err) {
-    // TODO if the failure was in the trigger install, should the function be left in place?
-    // Note that, in general, the deployer does not provide atomicity guarantees.  It can easily
-    // end up doing partial deploys in other ways.
+    // Note this is not the usual catch block for trigger deployment errors.   Those are caught in
+    // deployTriggers and fed back in the results.  The function itself will not be backed out if triggers
+    // fail to deploy.  Rather, both statuses are reported (success for the function and possibly some
+    // triggers, failure for those triggers that failed).  We reach here if the function fails to deploy
+    // or if system-level errors occurred in the logic somewhere.
     return Promise.resolve(wrapError(err, `action '${name}'`))
   }
 }

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -11,46 +11,73 @@
  * governing permissions and limitations under the License.
  */
 
-// Includes support for listing, installing, and removing triggers in the scheduling server, when such
-// triggers are attached to an action.  Currently, only sourceType=scheduler is supported for triggers.
-// Others will be rejected.  Eventually, this can be replaced by a dispatching discipline of some sort
-// that looks at the sourceType and calls specialized code for that source type.
+// Includes support for listing, installing, and removing triggers, when such triggers are attached to
+// an action.
 
-// TEMPORARY: some of this code is invoking actions in /nimbella/triggers/[create|delete|list] rather than
-// APIs more closely associated with the scheduling service.  Right now, there is dual behavior depending
-// on the environment variables TRIGGER_API_ENDPOINT and TRIGGER_API_TOKEN.  If both are non-blank, they
-// are used to contact the "real" endpoint.  Otherwise, the temporary actions are contacted.
-// The need for TRIGGER_API_TOKEN is not actually temporary: the deployer needs to get this information
-// somehow even when the dual mode behavior is retired.
+// TEMPORARY: some of this code will, if requested, invoke actions in /nimbella/triggers/[create|delete|list]
+// rather than the trigger APIs defined on api.digitalocean.com/v2/functions.  The actions in question
+// implement a prototype verion of the API which is still being used as a reference implementation until
+// the trigger APIs are stable and adequate.  The two are not functionally equivalent in that the prototype
+// API will result in updates to the public scheduling service (not the production one in DOCC).
+// 
+// To request the prototype API set TRIGGERS_USE_PROTOTYPE non-empty in the environment.
+//
+// Unless the prototype API is used, the DO_API_KEY environment variable must be set to the DO API key that
+// should be used to contact the DO API endpoint.  In doctl this key will be placed in the process 
+// environment of the subprocess that runs the deployer.   If the deployer is invoked via nim rather than
+// doctl, the invoking context must set this key (e.g. in the API build container or for testing).
+//
+// If neither environment variable is set, then trigger operations are skipped (become no-ops).
+// Reasoning: the deployer should always be called by one of
+//   - doctl, which will always set DO_API_KEY
+//   - tests, which will knowingly set one of the two
+//   - the AP build container, which should have maximum flexibility to either (1) refuse to deploy if
+// the project has triggers, (2) set DO_API_KEY in the subprocess enviornment when invoking nim, (3)
+// proceed with a warning and without deploying triggers.
+// And, the list operation, at least, will be called routinely during cleanup operations and must be
+// able to act as a no-op (return the empty list) when triggers are not being used.
 
 import openwhisk from 'openwhisk'
-import { TriggerSpec, SchedulerSourceDetails } from './deploy-struct'
-import axios from 'axios'
+import { TriggerSpec, SchedulerSourceDetails, DeploySuccess } from './deploy-struct'
+import { default as axios, AxiosRequestConfig } from 'axios'
 import makeDebug from 'debug'
 const debug = makeDebug('nim:deployer:triggers')
-const TRIGGER_API_ENDPOINT=process.env.TRIGGER_API_ENDPOINT
-const TRIGGER_API_TOKEN=process.env.DO_API_KEY
+const usePrototype=process.env.TRIGGERS_USE_PROTOTYPE
+const doAPIKey=process.env.DO_API_KEY
+const doAPIEndpoint='https://api.digitalocean.com'
 
 export async function deployTriggers(triggers: TriggerSpec[], functionName: string, wsk: openwhisk.Client,
-    namespace: string): Promise<object[]> {
-  const promises: Promise<object>[] = []
+    namespace: string): Promise<(DeploySuccess|Error)[]> {
+  const result: (DeploySuccess|Error)[] = []
   for (const trigger of triggers) {
-    promises.push(deployTrigger(trigger, functionName, wsk, namespace))   
+    result.push(await deployTrigger(trigger, functionName, wsk, namespace))   
   }
-  return Promise.all(promises)
+  debug('finished deploying triggers, returning result')
+  return result
 }
 
-export async function undeployTriggers(triggers: string[], wsk: openwhisk.Client, namespace: string): Promise<void> {
+export async function undeployTriggers(triggers: string[], wsk: openwhisk.Client, namespace: string): Promise<(Error|true)[]> {
+  const result: (Error|true)[] = []
   for (const trigger of triggers) {
-    await undeployTrigger(trigger, wsk, namespace)
+    try {
+      await undeployTrigger(trigger, wsk, namespace)
+      result.push(true)
+    } catch (err) {
+      // See comment in catch clause in deployTrigger
+      if (typeof err === 'string') {
+        result.push(Error(err))
+      } else {
+        result.push(err as Error)
+      }   
+    }
   }
+  return result
 }
 
-// Code to deploy a trigger.  Uses the prototype API unless TRIGGER_API_ENDPOINT
-//   and TRIGGER_API_TOKEN are set.
+// Code to deploy a trigger.
 // Note that basic structural validation of each trigger has been done previously
 // so paranoid checking is omitted.
-async function deployTrigger(trigger: TriggerSpec, functionName: string, wsk: openwhisk.Client, namespace: string): Promise<object> {
+async function deployTrigger(trigger: TriggerSpec, functionName: string, wsk: openwhisk.Client, namespace: string): Promise<DeploySuccess|Error> {
   const details = trigger.sourceDetails as SchedulerSourceDetails
   const { cron, withBody } = details
   const { sourceType, enabled } = trigger
@@ -63,89 +90,147 @@ async function deployTrigger(trigger: TriggerSpec, functionName: string, wsk: op
     overwrite: true,
     enabled
   }
-  if (TRIGGER_API_ENDPOINT && TRIGGER_API_TOKEN) {
-      return doTriggerCreate(trigger.name, functionName, namespace, cron)
+  try {
+    if (!usePrototype && doAPIKey) {
+        // Call the real API
+        debug('calling the real trigger API to create %s', trigger.name)
+        return await doTriggerCreate(trigger.name, functionName, namespace, cron, enabled)
+    } else if (usePrototype) {
+        // Call the prototype API
+        await wsk.actions.invoke({
+          name: '/nimbella/triggers/create',
+          params,
+          blocking: true,
+          result: true
+        })
+        return { name: trigger.name, kind: 'trigger', skipped: false }
+    }
+  } catch (err) {
+    debug('caught an error while deploying trigger; will return it')
+    // Assume 'err' is either string or Error in the following.  Actually it can be anything but use of
+    // other types is rare.
+    if (typeof err === 'string') {
+      return new Error(err)
+    }
+    return err as Error // TODO this could lead to a type error eventually if err isn't an Error
   }
-  return await wsk.actions.invoke({
-    name: '/nimbella/triggers/create',
-    params,
-    blocking: true,
-    result: true
-  })
+  // Neither envvar is set.  No-op
+  return { name: trigger.name, kind: 'trigger', skipped: true }
 }
 
-// Create a trigger using the real API
-async function doTriggerCreate(trigger: string, fcn: string, namespace: string, cron: string): Promise<object> {
-  const config = {
-    url: TRIGGER_API_ENDPOINT + '/v2/functions/trigger',
+// Create a trigger using the real API.  Note: the prototype API has the capability to do an UPSERT (by
+// setting the overwrite flag) and we use this.  Here, we need to simulate the effect by doing a speculative
+// delete, ignoring 404 errors (actually, we are ignoring all errors, which is probably adequate).
+async function doTriggerCreate(trigger: string, fcn: string, namespace: string, cron: string, enabled: boolean): Promise<DeploySuccess> {
+  try {
+    await doTriggerDelete(trigger, namespace)
+  } catch {}
+  const config: AxiosRequestConfig = {
+    url: doAPIEndpoint + '/v2/functions/trigger',
     method: 'post',
     data: {
       name: trigger,
       namespace,
       function: fcn,
+      is_enabled: enabled !== false, // ie, defaults to true
       trigger_source: 'SCHEDULED',
       cron
     }
   }
-  return doAxios(config)
+  await doAxios(config)
+  return { name: trigger, kind: 'trigger', skipped: false }
 }
 
 // Perform a network operation with axios, given a config object.
-async function doAxios(config: any): Promise<object> {
+// The config object should be complete except for headers.  The auth header
+// is added here.  The function assumes that doApiKey is set.
+async function doAxios(config: AxiosRequestConfig): Promise<object> {
+  config.headers = {
+    Authorization: `Bearer ${doAPIKey}`
+  }
   const response = await axios(config)
   return response.data
 }
 
-// Code to delete a trigger.  Uses the prototype API unless TRIGGER_API_ENDPOINT
-//   and TRIGGER_API_TOKEN are set.
+// Code to delete a trigger.
 async function undeployTrigger(trigger: string, wsk: openwhisk.Client, namespace: string) {
   debug('undeploying trigger %s', trigger)
-  if (TRIGGER_API_ENDPOINT && TRIGGER_API_TOKEN) {
+  if (doAPIKey && !usePrototype) {
+      // Use the real API
       return doTriggerDelete(trigger, namespace)
+  } else if (usePrototype) {
+    // Prototype API
+    const params = {
+      triggerName: trigger
+    }
+    return await wsk.actions.invoke({
+      name: '/nimbella/triggers/delete',
+      params,
+      blocking: true,
+      result: true
+    })
   }
-  const params = {
-    triggerName: trigger
-  }
-  return await wsk.actions.invoke({
-    name: '/nimbella/triggers/delete',
-    params,
-    blocking: true,
-    result: true
-  })
+  // Else no-up.  A Promise<void> (non-error) is returned implicitly
 }
 
 // Delete a trigger using the real API
 async function doTriggerDelete(trigger: string, namespace: string): Promise<object> {
-  const config = {
-    url: TRIGGER_API_ENDPOINT + `/v2/functions/trigger/${namespace}/${trigger}`,
-    method: 'delete',
+  const config: AxiosRequestConfig = {
+    url: doAPIEndpoint + `/v2/functions/trigger/${namespace}/${trigger}`,
+    method: 'delete'
   }
   return doAxios(config)
 }
 
 // Code to get all the triggers for a namespace, or all the triggers for a function in the
-// namespace.  Uses the prototype API unless TRIGGER_API_ENDPOINT and TRIGGER_API_TOKEN are set.
+// namespace.
 export async function listTriggersForNamespace(wsk: openwhisk.Client, namespace: string, fcn?: string): Promise<string[]> {
   debug('listing triggers')
-  if (TRIGGER_API_ENDPOINT && TRIGGER_API_TOKEN) {
+  if (doAPIKey && !usePrototype) {
+    // Use the real API
     return doTriggerList(namespace, fcn)
+  } else if (usePrototype) {
+    // Use the prototype API
+    const params: any = {
+      name: '/nimbella/triggers/list',
+      blocking: true,
+      result: true
+    }
+    if (fcn) {
+      params.params = { function: fcn }
+    }
+    const triggers: any = await wsk.actions.invoke(params)
+    debug('triggers listed')
+    return triggers.items.map((trigger: any) => trigger.triggerName)
   }
-  const params: any = {
-    name: '/nimbella/triggers/list',
-    blocking: true,
-    result: true
-  }
-  if (fcn) {
-    params.params = { function: fcn }
-  }
-  const triggers: any = await wsk.actions.invoke(params)
-  debug('triggers listed')
-  return triggers.items.map((trigger: any) => trigger.triggerName)
+  // No-op if no envvars are set
+  return []
 }
 
-// List triggers using the real API
-// TODO There are too many open questions on the real API concerning what information
-// will be returned.  So this is a "not implemented" for the moment.
+// The following is my best guess on what the trigger list API is planning to return
+interface TriggerList {
+  triggers: TriggerInfo[]
+}
+interface TriggerInfo {
+  name: string
+  function: string
+}
+
+// List triggers using the real API.  Currently, filtering by function is not
+// provided by the API so it is done here.
 async function doTriggerList(namespace: string, fcn: string): Promise<string[]> {
-  throw new Error('Listing triggers, hence cleaning up triggers, is not yet implemented')
+  const config: AxiosRequestConfig = {
+    url: doAPIEndpoint + `/v2/functions/triggers/${namespace}`,
+    method: 'get'
+  }
+  const triggers = await doAxios(config) as TriggerList
+  debug('got trigger list result from real API: %O', triggers)
+  if (!triggers.triggers) {
+    debug('result did not have triggers member')
+    return []
+  }
+  const filtered = fcn ? triggers.triggers.filter(trig => trig.function === fcn) : triggers.triggers
+  const names = filtered.map(trig => trig.name)
+  debug('reduced the list to %O', names)
+  return names
 }

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -16,34 +16,41 @@
 // Others will be rejected.  Eventually, this can be replaced by a dispatching discipline of some sort
 // that looks at the sourceType and calls specialized code for that source type.
 
-// TEMPORARY: this code is invoking actions in /nimbella/triggers/[create|delete|list] rather than
-// APIs more closely associated with the scheduling service.   This is likely to change if this
-// direction is adopted longer term. This should be the only file that has to change.
+// TEMPORARY: some of this code is invoking actions in /nimbella/triggers/[create|delete|list] rather than
+// APIs more closely associated with the scheduling service.  Right now, there is dual behavior depending
+// on the environment variables TRIGGER_API_ENDPOINT and TRIGGER_API_TOKEN.  If both are non-blank, they
+// are used to contact the "real" endpoint.  Otherwise, the temporary actions are contacted.
+// The need for TRIGGER_API_TOKEN is not actually temporary: the deployer needs to get this information
+// somehow even when the dual mode behavior is retired.
 
 import openwhisk from 'openwhisk'
 import { TriggerSpec, SchedulerSourceDetails } from './deploy-struct'
+import axios from 'axios'
 import makeDebug from 'debug'
 const debug = makeDebug('nim:deployer:triggers')
+const TRIGGER_API_ENDPOINT=process.env.TRIGGER_API_ENDPOINT
+const TRIGGER_API_TOKEN=process.env.DO_API_KEY
 
-export async function deployTriggers(triggers: TriggerSpec[], functionName: string, 
-    wsk: openwhisk.Client): Promise<object[]> {
+export async function deployTriggers(triggers: TriggerSpec[], functionName: string, wsk: openwhisk.Client,
+    namespace: string): Promise<object[]> {
   const promises: Promise<object>[] = []
   for (const trigger of triggers) {
-    promises.push(deployTrigger(trigger, functionName, wsk))   
+    promises.push(deployTrigger(trigger, functionName, wsk, namespace))   
   }
   return Promise.all(promises)
 }
 
-export async function undeployTriggers(triggers: string[], wsk: openwhisk.Client): Promise<void> {
+export async function undeployTriggers(triggers: string[], wsk: openwhisk.Client, namespace: string): Promise<void> {
   for (const trigger of triggers) {
-    await undeployTrigger(trigger, wsk)
+    await undeployTrigger(trigger, wsk, namespace)
   }
 }
 
-// Temporary code to deploy the trigger using the prototype API
+// Code to deploy a trigger.  Uses the prototype API unless TRIGGER_API_ENDPOINT
+//   and TRIGGER_API_TOKEN are set.
 // Note that basic structural validation of each trigger has been done previously
 // so paranoid checking is omitted.
-async function deployTrigger(trigger: TriggerSpec, functionName: string, wsk: openwhisk.Client): Promise<object> {
+async function deployTrigger(trigger: TriggerSpec, functionName: string, wsk: openwhisk.Client, namespace: string): Promise<object> {
   const details = trigger.sourceDetails as SchedulerSourceDetails
   const { cron, withBody } = details
   const { sourceType, enabled } = trigger
@@ -56,6 +63,9 @@ async function deployTrigger(trigger: TriggerSpec, functionName: string, wsk: op
     overwrite: true,
     enabled
   }
+  if (TRIGGER_API_ENDPOINT && TRIGGER_API_TOKEN) {
+      return doTriggerCreate(trigger.name, functionName, namespace, cron)
+  }
   return await wsk.actions.invoke({
     name: '/nimbella/triggers/create',
     params,
@@ -64,9 +74,35 @@ async function deployTrigger(trigger: TriggerSpec, functionName: string, wsk: op
   })
 }
 
-// Temporary code to undeploy a trigger using the prototype API
-async function undeployTrigger(trigger: string, wsk: openwhisk.Client) {
+// Create a trigger using the real API
+async function doTriggerCreate(trigger: string, fcn: string, namespace: string, cron: string): Promise<object> {
+  const config = {
+    url: TRIGGER_API_ENDPOINT + '/v2/functions/trigger',
+    method: 'post',
+    data: {
+      name: trigger,
+      namespace,
+      function: fcn,
+      trigger_source: 'SCHEDULED',
+      cron
+    }
+  }
+  return doAxios(config)
+}
+
+// Perform a network operation with axios, given a config object.
+async function doAxios(config: any): Promise<object> {
+  const response = await axios(config)
+  return response.data
+}
+
+// Code to delete a trigger.  Uses the prototype API unless TRIGGER_API_ENDPOINT
+//   and TRIGGER_API_TOKEN are set.
+async function undeployTrigger(trigger: string, wsk: openwhisk.Client, namespace: string) {
   debug('undeploying trigger %s', trigger)
+  if (TRIGGER_API_ENDPOINT && TRIGGER_API_TOKEN) {
+      return doTriggerDelete(trigger, namespace)
+  }
   const params = {
     triggerName: trigger
   }
@@ -78,10 +114,22 @@ async function undeployTrigger(trigger: string, wsk: openwhisk.Client) {
   })
 }
 
-// Temporary code to get all the triggers for a namespace, or all the triggers for a function in the
-// namespace, using the prototype API.
-export async function listTriggersForNamespace(wsk: openwhisk.Client, fcn?: string): Promise<string[]> {
+// Delete a trigger using the real API
+async function doTriggerDelete(trigger: string, namespace: string): Promise<object> {
+  const config = {
+    url: TRIGGER_API_ENDPOINT + `/v2/functions/trigger/${namespace}/${trigger}`,
+    method: 'delete',
+  }
+  return doAxios(config)
+}
+
+// Code to get all the triggers for a namespace, or all the triggers for a function in the
+// namespace.  Uses the prototype API unless TRIGGER_API_ENDPOINT and TRIGGER_API_TOKEN are set.
+export async function listTriggersForNamespace(wsk: openwhisk.Client, namespace: string, fcn?: string): Promise<string[]> {
   debug('listing triggers')
+  if (TRIGGER_API_ENDPOINT && TRIGGER_API_TOKEN) {
+    return doTriggerList(namespace, fcn)
+  }
   const params: any = {
     name: '/nimbella/triggers/list',
     blocking: true,
@@ -93,4 +141,11 @@ export async function listTriggersForNamespace(wsk: openwhisk.Client, fcn?: stri
   const triggers: any = await wsk.actions.invoke(params)
   debug('triggers listed')
   return triggers.items.map((trigger: any) => trigger.triggerName)
+}
+
+// List triggers using the real API
+// TODO There are too many open questions on the real API concerning what information
+// will be returned.  So this is a "not implemented" for the moment.
+async function doTriggerList(namespace: string, fcn: string): Promise<string[]> {
+  throw new Error('Listing triggers, hence cleaning up triggers, is not yet implemented')
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1222,6 +1222,8 @@ export async function wipe(client: Client): Promise<void> {
   if (triggers) {
     debug('There are %d DigitalOcean triggers to remove', triggers.length)
     await undeployTriggers(triggers, client, namespace)
+    // TODO errors are being fed back here but are currently ignored.  It is not completely
+    // clear what should be done with them.
   }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1217,10 +1217,11 @@ export async function wipe(client: Client): Promise<void> {
   debug('OpenWhisk triggers wiped')
   await wipeAll(client.packages, 'Package')
   debug('Packages wiped')
-  const triggers = await listTriggersForNamespace(client)
+  const namespace = await getTargetNamespace(client)
+  const triggers = await listTriggersForNamespace(client, namespace)
   if (triggers) {
     debug('There are %d DigitalOcean triggers to remove', triggers.length)
-    await undeployTriggers(triggers, client)
+    await undeployTriggers(triggers, client, namespace)
   }
 }
 
@@ -1250,8 +1251,9 @@ export async function deleteAction(actionName: string, owClient: Client): Promis
   // Save the action contents so they can be returned as a result.
   const action = await owClient.actions.delete({ name: actionName})
   // Delete associated triggers (if any)
-  const triggers = await listTriggersForNamespace(owClient, actionName)
-  await undeployTriggers(triggers, owClient)
+  const namespace = await getTargetNamespace(owClient)
+  const triggers = await listTriggersForNamespace(owClient, namespace, actionName)
+  await undeployTriggers(triggers, owClient, namespace)
   return action
 }
 


### PR DESCRIPTION
Starting with release 4.3.0 the deployer has had some support for triggers (not OpenWhisk triggers, rather, DigitalOcean triggers, which are stored external to the OpenWhisk cluster).   Up until this change, the trigger list/create/delete API was a temporary one, to support development and proof of concept.   With this change, there is a switch to an API that is a candidate for the eventual "official" API that DigitalOcean intends to support.   At present, however, all triggers APIs are unsupported and subject to change.

Once this new deployer is connected to `nim` and `doctl` more information will be provided about how to use it.