### PR TITLE
Ensure a more orderly deletion when using triggers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@nimbella/storage": "^0.0.7",
         "@octokit/rest": "^18.7.0",
         "adm-zip": "^0.4.16",
-        "aggregate-error": "^4.0.1",
         "anymatch": "^3.1.1",
         "archiver": "^5.3.0",
         "atob": "^2.1.2",
@@ -2741,21 +2740,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/aggregate-error": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
-      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-      "dependencies": {
-        "clean-stack": "^4.0.0",
-        "indent-string": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -3271,31 +3255,6 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
-    },
-    "node_modules/clean-stack": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-      "dependencies": {
-        "escape-string-regexp": "5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clean-stack/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -4651,17 +4610,6 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "engines": {
         "node": ">=0.8.19"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/inflight": {
@@ -9678,15 +9626,6 @@
         "debug": "4"
       }
     },
-    "aggregate-error": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
-      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-      "requires": {
-        "clean-stack": "^4.0.0",
-        "indent-string": "^5.0.0"
-      }
-    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -10066,21 +10005,6 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
-    },
-    "clean-stack": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-      "requires": {
-        "escape-string-regexp": "5.0.0"
-      },
-      "dependencies": {
-        "escape-string-regexp": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
-        }
-      }
     },
     "cliui": {
       "version": "7.0.4",
@@ -10988,11 +10912,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-    },
-    "indent-string": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
     },
     "inflight": {
       "version": "1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-deployer",
-      "version": "4.3.8",
+      "version": "4.3.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",
@@ -14,6 +14,7 @@
         "@nimbella/storage": "^0.0.7",
         "@octokit/rest": "^18.7.0",
         "adm-zip": "^0.4.16",
+        "aggregate-error": "^4.0.1",
         "anymatch": "^3.1.1",
         "archiver": "^5.3.0",
         "atob": "^2.1.2",
@@ -2740,6 +2741,21 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/aggregate-error": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
+      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
+      "dependencies": {
+        "clean-stack": "^4.0.0",
+        "indent-string": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -3255,6 +3271,31 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "node_modules/clean-stack": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clean-stack/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -4610,6 +4651,17 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/inflight": {
@@ -9626,6 +9678,15 @@
         "debug": "4"
       }
     },
+    "aggregate-error": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
+      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
+      "requires": {
+        "clean-stack": "^4.0.0",
+        "indent-string": "^5.0.0"
+      }
+    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -10005,6 +10066,21 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "clean-stack": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+      "requires": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+        }
+      }
     },
     "cliui": {
       "version": "7.0.4",
@@ -10912,6 +10988,11 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+    },
+    "indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
     },
     "inflight": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@nimbella/storage": "^0.0.7",
     "@octokit/rest": "^18.7.0",
     "adm-zip": "^0.4.16",
-    "aggregate-error": "^4.0.1",
     "anymatch": "^3.1.1",
     "archiver": "^5.3.0",
     "atob": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {
@@ -16,6 +16,7 @@
     "@nimbella/storage": "^0.0.7",
     "@octokit/rest": "^18.7.0",
     "adm-zip": "^0.4.16",
+    "aggregate-error": "^4.0.1",
     "anymatch": "^3.1.1",
     "archiver": "^5.3.0",
     "atob": "^2.1.2",

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -586,7 +586,7 @@ async function deployActionFromCodeOrSequence(action: ActionSpec, spec: DeploySt
     
     let triggerResults: (DeploySuccess|Error)[] = []
     if (action.triggers) {
-      triggerResults = await deployTriggers(action.triggers, name, wsk, spec.credentials.namespace)
+      triggerResults = await deployTriggers(action.triggers, name, spec.credentials.namespace)
     }
     const map = {}
     if (digest) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -30,6 +30,7 @@ import * as crypto from 'crypto'
 import * as yaml from 'js-yaml'
 import makeDebug from 'debug'
 import anymatch from 'anymatch'
+import AggregateError from 'aggregate-error'
 import { parseGithubRef } from './github'
 import { nimbellaDir } from './credentials'
 import { isBinaryFileExtension, runtimeForZipMid, runtimeForFileExtension, RuntimesConfig, isValidRuntime} from './runtimes'
@@ -1207,29 +1208,48 @@ function deployerAnnotationFromGithub(githubPath: string): DeployerAnnotation {
   return { digest: undefined, user: 'cloud', repository, projectPath: def.path, commit: def.ref || 'master' }
 }
 
-// Wipe all the entities from the namespace referred to by an OW client handle
+// Wipe all the entities from the namespace referred to by an OW client handle.
+// This is not guaranteed to succeed but it will attempt to wipe as much as possible,
+// returning all errors that occurred.  If an error occurs when removing a trigger that
+// is associated with a function, the function is not deleted.
 export async function wipe(client: Client): Promise<void> {
-  await wipeAll(client.actions, 'Action')
+  const errors: any[] = []
+  // Delete the actions, which will delete associated triggers if possible.  If a trigger
+  // cannot be deleted, the action is left also.
+  await wipeActions(client, errors)
   debug('Actions wiped')
-  await wipeAll(client.rules, 'Rule')
-  debug('Rules wiped')
-  await wipeAll(client.triggers, 'Trigger')
-  debug('OpenWhisk triggers wiped')
-  await wipeAll(client.packages, 'Package')
+  // Delete the packages.  Note that if an action deletion failed, the containing
+  // package will likely fail also.
+  await wipeAll(client.packages, 'Package', errors)
   debug('Packages wiped')
+  // There _could_ have been orphaned triggers that were not deleted when we
+  // deleted actions (since they were not connected to an existing action).
+  // On the other hand, if one or more triggers failed deletion before, they
+  // may fail again here, with duplicate errors.  We are tolerating that for the moment.
   const namespace = await getTargetNamespace(client)
-  const triggers = await listTriggersForNamespace(client, namespace)
-  if (triggers) {
-    debug('There are %d DigitalOcean triggers to remove', triggers.length)
-    await undeployTriggers(triggers, client, namespace)
-    // TODO errors are being fed back here but are currently ignored.  It is not completely
-    // clear what should be done with them.
+  const triggers = await listTriggersForNamespace(namespace, '')
+  const errs = await undeployTriggers(triggers, namespace)
+  if (errs.length > 0) {
+    errors.push(...errs)
+  }
+  // Delete rules and OpenWhisk triggers for good measure (there really shouldn't be any)
+  await wipeAll(client.rules, 'Rule', errors)
+  debug('Rules wiped')
+  await wipeAll(client.triggers, 'Trigger', errors)
+  debug('OpenWhisk triggers wiped')
+  // Determine if any errors occurred.  If so, throw them.  We use an AggregateError if there is more than one.
+  if (errors.length > 1) {
+    throw new AggregateError(errors)
+  } 
+  if (errors.length == 1){
+    throw errors[0]
   }
 }
 
-// Repeatedly wipe an entity (action, rule, trigger, or package) from the namespace denoted by the OW client until none are left
-// Note that the list function can only return 200 entities at a time)
-async function wipeAll(handle: any, kind: string) {
+// Repeatedly wipe an entity (rule, trigger, or package) from the namespace denoted by the OW client until none are left
+// Note that the list function can only return 200 entities at a time).
+// Actions are handled differently since they may have triggers associated with them.
+async function wipeAll(handle: any, kind: string, errors: any[]) {
   while (true) {
     const entities = await handle.list({ limit: 200 })
     if (entities.length === 0) {
@@ -1241,22 +1261,62 @@ async function wipeAll(handle: any, kind: string) {
       if (nsparts.length > 1) {
         name = nsparts[1] + '/' + name
       }
-      await handle.delete(name)
-      debug('%s %s deleted', kind, name)
+      try {
+        await handle.delete(name)
+        debug('%s %s deleted', kind, name)
+      } catch (err) {
+        debug('error deleting %s %s: %O', err)
+        errors.push(err)    
+      }
     }
   }
 }
 
-// Delete an action while also deleting any DigitalOcean triggers that are targetting it
-export async function deleteAction(actionName: string, owClient: Client): Promise<Action> {
-  // First delete the action itself.  If this fails it will throw.
-  // Save the action contents so they can be returned as a result.
-  const action = await owClient.actions.delete({ name: actionName})
-  // Delete associated triggers (if any)
+// Repeatedly wipe actions from the namespace denoted by the OW client until none are left.
+// Note that the list function can only return 200 actions at a time.  This is done
+// differently from the other entity types because actions can have associated triggers
+// which should be deleted first (with the action remaining if the trigger deletion fails).
+async function wipeActions(client: Client, errors: any[]) {
+  while (true) {
+    const actions = await client.actions.list({ limit: 200 })
+    if (actions.length === 0) {
+      return
+    }
+    for (const action of actions) {
+      let name = action.name
+      const nsparts = action.namespace.split('/')
+      if (nsparts.length > 1) {
+        name = nsparts[1] + '/' + name
+      }
+      const result = await deleteAction(name, client)
+      if (Array.isArray(result)) {
+        errors.push(...result)
+        debug('error deleting the triggers')
+      }
+      debug('action %s deleted', name)
+    }
+  }
+}
+
+// Delete an action after first deleting any DigitalOcean triggers that are targeting it.
+// If we can't delete the triggers, we don't delete the action (maintains the invariant that
+// a trigger should only exist if its invoked function also exists).  This function is not
+// intended to throw but to return errors in an array (either errors deleting triggers or an
+// error deleting the action).
+export async function deleteAction(actionName: string, owClient: Client): Promise<Action|Error[]> {
+  // Delete triggers.
   const namespace = await getTargetNamespace(owClient)
-  const triggers = await listTriggersForNamespace(owClient, namespace, actionName)
-  await undeployTriggers(triggers, owClient, namespace)
-  return action
+  const triggers = await listTriggersForNamespace(namespace, actionName)
+  const errs = await undeployTriggers(triggers, namespace)
+  if (errs.length > 0) {
+    return errs
+  }
+  try {
+    return await owClient.actions.delete({ name: actionName})
+  } catch (err) {
+    const msg = err.message ? err.message : err
+    return [ new Error(`unable to undeploy action '${actionName}': ${msg}`) ]   
+  }
 }
 
 // Generate a secret in the form of a random alphameric string (TODO what form(s) do we actually support)


### PR DESCRIPTION
The deployer attempts to delete triggers in two cases:
- when requested to clean a namespace
- when deleting a function (it checks for triggers associated with that function and deletes them)

The first version of this capability deleted the function(s) first and the triggers afterwards.   This opens the possibility of a partial failure where the function is deleted but not one or more of its triggers.   Although we can tolerate a short window during which a trigger exists without its function, we do not want to allow such orphaned triggers to persist or accumulate.

This change re-orders operations so that triggers are always deleted before the function they are bound to.  Furthermore, if trigger deletion fails, the function deletion is skipped.    The error reporting for trigger failures is thus a little more complicated since it is important to convey what was done and not done.  Consequently, the error handling in these sections of the deployer was revamped.

As part of this change, I also removed support in the deployer for using the so-called prototype API (which we used to support development of UI and CLI components before the real API was available).   All trigger operations now go to the real API.