### PR TITLE
Fail silently if call is unable to use trigger API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.3.9",
+  "version": "4.3.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nimbella/nimbella-deployer",
-      "version": "4.3.9",
+      "version": "4.3.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbella/nimbella-deployer",
-  "version": "4.3.9",
+  "version": "4.3.10",
   "description": "The Nimbella platform deployer library",
   "main": "lib/index.js",
   "repository": {

--- a/src/triggers.ts
+++ b/src/triggers.ts
@@ -160,8 +160,14 @@ async function doTriggerList(namespace: string, fcn: string): Promise<string[]> 
     url: doAPIEndpoint + `/v2/functions/triggers/${namespace}`,
     method: 'get'
   }
-  const triggers = await doAxios(config) as TriggerList
-  debug('got trigger list result from real API: %O', triggers)
+  let triggers: TriggerList
+  try {
+    triggers = await doAxios(config) as TriggerList
+  } catch (err) {
+    debug('error listing triggers: %s', err.message)
+    return [] 
+  }
+  debug('got trigger list result from the API: %O', triggers)
   if (!triggers.triggers) {
     debug('result did not have triggers member')
     return []


### PR DESCRIPTION
During the beta period for scheduled functions in DigitalOcean, the deployer must not throw an error just because the caller is unable to list triggers.   The list triggers API call is made routinely during "wipe" operations (namespace or package) or when an action is deleted.  Some users won't be enabled for the triggers API, so the list request will fail.  Such users don't have any triggers anyway, so the appropriate response is to return an empty list and proceed.